### PR TITLE
Pin requirements to exact versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-websockets>=8.1
+websockets==10.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-wheel
-pre-commit
+wheel==0.37.1
+pre-commit==2.16.0
 
 -e .


### PR DESCRIPTION
Pin requirements in `requirements.txt` and `requirements_dev.txt` to exact versions.
