### PR TITLE
Cleanup exceptions

### DIFF
--- a/aiowebostv/__init__.py
+++ b/aiowebostv/__init__.py
@@ -1,5 +1,5 @@
 """Provide a package for controlling LG webOS based TVs."""
-from .exceptions import WebOsTvCmdException, WebOsTvPairException
+from .exceptions import WebOsTvCommandError, WebOsTvPairError
 from .webos_client import WebOsClient
 
-__all__ = ["WebOsTvCmdException", "WebOsTvPairException", "WebOsClient"]
+__all__ = ["WebOsTvCommandError", "WebOsTvPairError", "WebOsClient"]

--- a/aiowebostv/__init__.py
+++ b/aiowebostv/__init__.py
@@ -1,5 +1,5 @@
 """Provide a package for controlling LG webOS based TVs."""
-from .exceptions import PyLGTVCmdException, PyLGTVPairException
+from .exceptions import WebOsTvCmdException, WebOsTvPairException
 from .webos_client import WebOsClient
 
-__all__ = ["PyLGTVCmdException", "PyLGTVPairException", "WebOsClient"]
+__all__ = ["WebOsTvCmdException", "WebOsTvPairException", "WebOsClient"]

--- a/aiowebostv/exceptions.py
+++ b/aiowebostv/exceptions.py
@@ -1,17 +1,21 @@
 """Exceptions for aiowebostv."""
 
 
-class WebOsTvPairException(Exception):
-    """Exception raised to represent TV pairing errors."""
+class WebOsTvError(Exception):
+    """Base exception for aiowebostv."""
 
 
-class WebOsTvCmdException(Exception):
-    """Exception raised to represent TV command exceptions."""
+class WebOsTvPairError(WebOsTvError):
+    """Represent TV pairing errors."""
 
 
-class WebOsTvCmdError(WebOsTvCmdException):
-    """Exception raised to represent TV command errors."""
+class WebOsTvCommandError(WebOsTvError):
+    """Represent TV command errors."""
 
 
-class WebOsTvServiceNotFoundError(WebOsTvCmdError):
-    """Exception raised to represent TV service not found error."""
+class WebOsTvResponseTypeError(WebOsTvCommandError):
+    """Represent TV responded with error type."""
+
+
+class WebOsTvServiceNotFoundError(WebOsTvResponseTypeError):
+    """Represent TV service not found error."""

--- a/aiowebostv/exceptions.py
+++ b/aiowebostv/exceptions.py
@@ -1,17 +1,17 @@
 """Exceptions for aiowebostv."""
 
 
-class PyLGTVPairException(Exception):
+class WebOsTvPairException(Exception):
     """Exception raised to represent TV pairing errors."""
 
 
-class PyLGTVCmdException(Exception):
+class WebOsTvCmdException(Exception):
     """Exception raised to represent TV command exceptions."""
 
 
-class PyLGTVCmdError(PyLGTVCmdException):
+class WebOsTvCmdError(WebOsTvCmdException):
     """Exception raised to represent TV command errors."""
 
 
-class PyLGTVServiceNotFoundError(PyLGTVCmdError):
+class WebOsTvServiceNotFoundError(WebOsTvCmdError):
     """Exception raised to represent TV service not found error."""

--- a/aiowebostv/webos_client.py
+++ b/aiowebostv/webos_client.py
@@ -10,10 +10,10 @@ import websockets
 
 from . import endpoints as ep
 from .exceptions import (
-    PyLGTVCmdError,
-    PyLGTVCmdException,
-    PyLGTVPairException,
-    PyLGTVServiceNotFoundError,
+    WebOsTvCmdError,
+    WebOsTvCmdException,
+    WebOsTvPairException,
+    WebOsTvServiceNotFoundError,
 )
 from .handshake import REGISTRATION_MESSAGE
 
@@ -114,7 +114,7 @@ class WebOsClient:
             if response["type"] == "hello":
                 self._hello_info = response["payload"]
             else:
-                raise PyLGTVPairException("Unable to say hello")
+                raise WebOsTvCmdException(f"Invalid request type {response}")
 
             # send registration
             await main_ws.send(json.dumps(self.registration_msg()))
@@ -131,7 +131,7 @@ class WebOsClient:
                     self.client_key = response["payload"]["client-key"]
 
             if not self.client_key:
-                raise PyLGTVPairException("Unable to pair")
+                raise WebOsTvPairException("Unable to pair")
 
             self.callbacks = {}
             self.futures = {}
@@ -199,7 +199,7 @@ class WebOsClient:
             for task in subscribe_tasks:
                 try:
                     task.result()
-                except PyLGTVServiceNotFoundError:
+                except WebOsTvServiceNotFoundError:
                     pass
             # set placeholder power state if not available
             if not self._power_state:
@@ -476,13 +476,13 @@ class WebOsClient:
         if self._channels is None:
             try:
                 await self.subscribe_channels(self.set_channels_state)
-            except PyLGTVCmdException:
+            except WebOsTvCmdException:
                 pass
 
         if app_id == "com.webos.app.livetv" and self._current_channel is None:
             try:
                 await self.subscribe_current_channel(self.set_current_channel_state)
-            except PyLGTVCmdException:
+            except WebOsTvCmdException:
                 pass
 
         if self.state_update_callbacks and self.do_state_update:
@@ -519,7 +519,7 @@ class WebOsClient:
         if self._channel_info is None:
             try:
                 await self.subscribe_channel_info(self.set_channel_info_state)
-            except PyLGTVCmdException:
+            except WebOsTvCmdException:
                 pass
 
         if self.state_update_callbacks and self.do_state_update:
@@ -585,7 +585,7 @@ class WebOsClient:
         }
 
         if self.connection is None:
-            raise PyLGTVCmdException("Not connected, can't execute command.")
+            raise WebOsTvCmdException("Not connected, can't execute command.")
 
         await self.connection.send(json.dumps(message))
 
@@ -598,7 +598,7 @@ class WebOsClient:
         self.futures[uid] = res
         try:
             await self.command(cmd_type, uri, payload, uid)
-        except (asyncio.CancelledError, PyLGTVCmdException):
+        except (asyncio.CancelledError, WebOsTvCmdException):
             del self.futures[uid]
             raise
         try:
@@ -611,19 +611,19 @@ class WebOsClient:
 
         payload = response.get("payload")
         if payload is None:
-            raise PyLGTVCmdException(f"Invalid request response {response}")
+            raise WebOsTvCmdException(f"Invalid request response {response}")
 
         return_value = payload.get("returnValue") or payload.get("subscribed")
 
         if response.get("type") == "error":
             error = response.get("error")
             if error == "404 no such service or method":
-                raise PyLGTVServiceNotFoundError(error)
-            raise PyLGTVCmdError(response)
+                raise WebOsTvServiceNotFoundError(error)
+            raise WebOsTvCmdError(response)
         if return_value is None:
-            raise PyLGTVCmdException(f"Invalid request response {response}")
+            raise WebOsTvCmdException(f"Invalid request response {response}")
         if not return_value:
-            raise PyLGTVCmdException(f"Request failed with response {response}")
+            raise WebOsTvCmdException(f"Request failed with response {response}")
 
         return payload
 
@@ -643,7 +643,7 @@ class WebOsClient:
     async def input_command(self, message):
         """Execute TV input command."""
         if self.input_connection is None:
-            raise PyLGTVCmdException("Couldn't execute input command.")
+            raise WebOsTvCmdException("Couldn't execute input command.")
 
         await self.input_connection.send(message)
 

--- a/examples/reconnect.py
+++ b/examples/reconnect.py
@@ -4,7 +4,7 @@ from contextlib import suppress
 from datetime import datetime
 
 from aiowebostv import WebOsClient
-from aiowebostv.exceptions import PyLGTVCmdException
+from aiowebostv.exceptions import WebOsTvCmdException
 from websockets.exceptions import ConnectionClosed, ConnectionClosedOK
 
 WEBOSTV_EXCEPTIONS = (
@@ -12,7 +12,7 @@ WEBOSTV_EXCEPTIONS = (
     ConnectionClosed,
     ConnectionClosedOK,
     ConnectionRefusedError,
-    PyLGTVCmdException,
+    WebOsTvCmdException,
     asyncio.TimeoutError,
     asyncio.CancelledError,
 )

--- a/examples/reconnect.py
+++ b/examples/reconnect.py
@@ -4,7 +4,7 @@ from contextlib import suppress
 from datetime import datetime
 
 from aiowebostv import WebOsClient
-from aiowebostv.exceptions import WebOsTvCmdException
+from aiowebostv.exceptions import WebOsTvCommandError
 from websockets.exceptions import ConnectionClosed, ConnectionClosedOK
 
 WEBOSTV_EXCEPTIONS = (
@@ -12,7 +12,7 @@ WEBOSTV_EXCEPTIONS = (
     ConnectionClosed,
     ConnectionClosedOK,
     ConnectionRefusedError,
-    WebOsTvCmdException,
+    WebOsTvCommandError,
     asyncio.TimeoutError,
     asyncio.CancelledError,
 )


### PR DESCRIPTION
- Add base exception (`WebOsTvError`).
- Fix wrong exception raised during hello.
- Rename exceptions to match new package name and better meaning of the error:
`PyLGTVPairException` --> `WebOsTvPairError`
`PyLGTVCmdException` --> `WebOsTvCommandError`
`PyLGTVCmdError` --> `WebOsTvResponseTypeError`
`PyLGTVServiceNotFoundError` --> `WebOsTvServiceNotFoundError`

