### PR TITLE
Add GitHub workflows

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Report a bug with LG webOS Smart TV
+    url: https://github.com/home-assistant/core/issues
+    about: Please report issues with LG webOS Smart TV in the Home Assistant core repository unless a developer told you otherwise.
+  - name: I have a question or need support
+    url: https://www.home-assistant.io/help
+    about: We use GitHub for tracking bugs, check the Home Assistant website for resources on getting help.
+  - name: Feature Request
+    url: https://community.home-assistant.io/c/feature-requests
+    about: Please use the Home Assistant Community Forum for making feature requests.
+  - name: I'm unsure where to go
+    url: https://www.home-assistant.io/join-chat
+    about: If you are unsure where to go, then joining our chat is recommended; Just ask!

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+  - package-ecosystem: "pip"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,9 @@
+change-template: "- #$NUMBER - $TITLE (@$AUTHOR)"
+categories:
+  - title: "⚠ Breaking Changes"
+    labels:
+      - "breaking change"
+template: |
+  ## What’s Changed
+
+  $CHANGES

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,27 @@
+name: Publish releases to PyPI
+
+on:
+  release:
+    types: [published, prereleased]
+
+jobs:
+  build-and-publish:
+    name: Builds and publishes releases to PyPI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2.3.1
+        with:
+          python-version: 3.8
+      - name: Install wheel
+        run: >-
+          pip install wheel
+      - name: Build
+        run: >-
+          python3 setup.py sdist bdist_wheel
+      - name: Publish release to PyPI
+        uses: pypa/gh-action-pypi-publish@main
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -9,7 +9,7 @@ jobs:
     name: Builds and publishes releases to PyPI
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v2.4.0
       - name: Set up Python 3.8
         uses: actions/setup-python@v2.3.1
         with:
@@ -21,7 +21,7 @@ jobs:
         run: >-
           python3 setup.py sdist bdist_wheel
       - name: Publish release to PyPI
-        uses: pypa/gh-action-pypi-publish@main
+        uses: pypa/gh-action-pypi-publish@v1.4.2
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,15 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "main"
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Based on templates from https://github.com/home-assistant-libs/zwave-js-server-python
- Add issue template
- Dependabot
- Release drafter
- Publish to PyPi
