### PR TITLE
Add linting and CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+# This workflow will install Python dependencies, run tests and lint
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version:
+          - "3.8"
+          - "3.9"
+          - "3.10"
+
+    steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2.3.1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox tox-gh-actions
+      - name: Test with tox
+        run: tox

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     -   id: check-yaml
     -   id: debug-statements
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.8
+    rev: 4.0.1
     hooks:
     -   id: flake8
         args:
@@ -17,17 +17,17 @@ repos:
           - --max-complexity=18
           - --select=B,C,E,F,W,T4,B9
 -   repo: https://github.com/ambv/black
-    rev: 19.3b0
+    rev: 21.12b0
     hooks:
     - id: black
       language_version: python3
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v1.25.2
+    rev: v2.31.0
     hooks:
     -   id: pyupgrade
-        args: ['--py37-plus']
+        args: ['--py38-plus']
 -   repo: https://github.com/pre-commit/mirrors-isort
-    rev: v4.3.21
+    rev: v5.10.1
     hooks:
     -   id: isort
         args:
@@ -36,3 +36,11 @@ repos:
           - --force-grid-wrap=0
           - --use-parentheses
           - --line-width=88
+-   repo: https://github.com/PyCQA/pydocstyle
+    rev: 6.1.1
+    hooks:
+    -   id: pydocstyle
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: 'v0.930'
+    hooks:
+    -   id: mypy

--- a/aiowebostv/endpoints.py
+++ b/aiowebostv/endpoints.py
@@ -1,4 +1,4 @@
-""""webOS TV public SSAP API endpoints."""
+"""webOS TV public SSAP API endpoints."""
 GET_SERVICES = "api/getServiceList"
 SET_MUTE = "audio/setMute"
 GET_AUDIO_STATUS = "audio/getStatus"

--- a/aiowebostv/webos_client.py
+++ b/aiowebostv/webos_client.py
@@ -82,7 +82,7 @@ class WebOsClient:
         return self.client_key is not None
 
     def is_connected(self):
-        """Connected to the tv."""
+        """Return true if connected to the tv."""
         return self.connect_task is not None and not self.connect_task.done()
 
     def registration_msg(self):
@@ -92,13 +92,14 @@ class WebOsClient:
         return handshake
 
     async def connect_handler(self, res):
-        """webOS TV Connection handler."""
+        """Connect handler for webOS TV."""
+        # pylint: disable=too-many-locals,too-many-statements
         handler_tasks = set()
         main_ws = None
         input_ws = None
         try:
             main_ws = await asyncio.wait_for(
-                websockets.connect(
+                websockets.client.connect(
                     f"ws://{self.host}:{self.port}",
                     ping_interval=None,
                     close_timeout=self.timeout_connect,
@@ -158,7 +159,7 @@ class WebOsClient:
             sockres = await self.request(ep.INPUT_SOCKET)
             inputsockpath = sockres.get("socketPath")
             input_ws = await asyncio.wait_for(
-                websockets.connect(
+                websockets.client.connect(
                     inputsockpath,
                     ping_interval=None,
                     close_timeout=self.timeout_connect,
@@ -213,7 +214,7 @@ class WebOsClient:
 
             await asyncio.wait(handler_tasks, return_when=asyncio.FIRST_COMPLETED)
 
-        except Exception as ex:
+        except Exception as ex:  # pylint: disable=broad-except
             if not res.done():
                 res.set_exception(ex)
         finally:
@@ -284,7 +285,7 @@ class WebOsClient:
 
     @staticmethod
     async def callback_handler(queue, callback, future):
-        """Callback handler."""
+        """Handle callbacks."""
         try:
             while True:
                 msg = await queue.get()
@@ -468,10 +469,10 @@ class WebOsClient:
             await self.do_state_update_callbacks()
 
     async def set_current_app_state(self, app_id):
-        """Set current app state variable.
-        This function also handles subscriptions to current channel and channel list,
-        since the current channel subscription can only succeed when Live TV is running,
-        and the channel list subscription can only succeed after channels have been configured."""
+        """Set current app state variable."""
+        # This function also handles subscriptions to current channel and channel list,
+        # since the current channel subscription can only succeed when Live TV is running,
+        # and the channel list subscription can only succeed after channels have been configured.
         self._current_app_id = app_id
 
         if self._channels is None:
@@ -511,10 +512,9 @@ class WebOsClient:
             await self.do_state_update_callbacks()
 
     async def set_current_channel_state(self, channel):
-        """Set current channel state variable.
-        This function also handles the channel info subscription,
-        since that call may fail if channel information is not available when it's called."""
-
+        """Set current channel state variable."""
+        # This function also handles the channel info subscription,
+        # since that call may fail if channel information is not available when it's called."""
         self._current_channel = channel
 
         if self._channel_info is None:
@@ -652,25 +652,21 @@ class WebOsClient:
 
     async def button(self, name):
         """Send button press command."""
-
         message = f"type:button\nname:{name}\n\n"
         await self.input_command(message)
 
     async def move(self, d_x, d_y, down=0):
         """Send cursor move command."""
-
         message = f"type:move\ndx:{d_x}\ndy:{d_y}\ndown:{down}\n\n"
         await self.input_command(message)
 
     async def click(self):
         """Send cursor click command."""
-
         message = "type:click\n\n"
         await self.input_command(message)
 
     async def scroll(self, d_x, d_y):
         """Send scroll command."""
-
         message = f"type:scroll\ndx:{d_x}\ndy:{d_y}\n\n"
         await self.input_command(message)
 
@@ -761,7 +757,6 @@ class WebOsClient:
 
     async def power_off(self):
         """Power off TV."""
-
         # protect against turning tv back on if it is off
         if not self.is_on:
             return
@@ -775,9 +770,7 @@ class WebOsClient:
         return await self.request(ep.POWER_ON)
 
     async def turn_screen_off(self, webos_ver=""):
-        """Turn TV Screen off. standbyMode values: 'active' or 'passive',
-        passive cannot turn screen back on, need to pull TV plug.
-        """
+        """Turn TV Screen off."""
         ep_name = f"TURN_OFF_SCREEN_WO{webos_ver}" if webos_ver else "TURN_OFF_SCREEN"
 
         if not hasattr(ep, ep_name):
@@ -786,9 +779,7 @@ class WebOsClient:
         return await self.request(getattr(ep, ep_name), {"standbyMode": "active"})
 
     async def turn_screen_on(self, webos_ver=""):
-        """Turn TV Screen on. standbyMode values: 'active' or 'passive',
-        passive cannot turn screen back on, need to pull TV plug.
-        """
+        """Turn TV Screen on."""
         ep_name = f"TURN_ON_SCREEN_WO{webos_ver}" if webos_ver else "TURN_ON_SCREEN"
 
         if not hasattr(ep, ep_name):
@@ -829,7 +820,7 @@ class WebOsClient:
 
     # Audio
     async def get_audio_status(self):
-        """Get the current audio status"""
+        """Get the current audio status."""
         return await self.request(ep.GET_AUDIO_STATUS)
 
     async def get_muted(self):
@@ -876,8 +867,8 @@ class WebOsClient:
         return await self._volume_step(ep.VOLUME_DOWN)
 
     async def _volume_step(self, endpoint):
-        """Volume step and conditionally sleep afterwards
-        if a consecutive volume step shouldn't be possible to perform immediately after."""
+        """Volume step and conditionally sleep afterwards."""
+        # if a consecutive volume step shouldn't be possible to perform immediately after.
         if (
             self.sound_output in SOUND_OUTPUTS_TO_DELAY_CONSECUTIVE_VOLUME_STEPS
             and self._volume_step_delay is not None

--- a/pylintrc
+++ b/pylintrc
@@ -1,0 +1,31 @@
+[MASTER]
+ignore=tests
+# Use a conservative default here; 2 should speed up most setups and not hurt
+# any too bad. Override on command line as appropriate.
+jobs=2
+persistent=no
+
+[BASIC]
+good-names=id,i,j,k,ex,Run,_,fp
+max-attributes=15
+
+[MESSAGES CONTROL]
+# Reasons disabled:
+# too-many-* - are not enforced for the sake of readability
+# too-few-* - same as too-many-*
+disable=
+  too-few-public-methods,
+  too-many-arguments,
+  too-many-public-methods,
+  too-many-instance-attributes,
+  too-many-branches
+
+[REPORTS]
+score=no
+
+[TYPECHECK]
+# For attrs
+ignored-classes=_CountingAttr
+
+[FORMAT]
+expected-line-ending-format=LF

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,7 @@
 -r requirements.txt
-wheel==0.37.1
+-r requirements_lint.txt
 pre-commit==2.16.0
+tox==3.24.5
+wheel==0.37.1
 
 -e .

--- a/requirements_lint.txt
+++ b/requirements_lint.txt
@@ -1,0 +1,6 @@
+black==21.12b0
+flake8==4.0.1
+isort==5.10.1
+mypy==0.930
+pydocstyle==6.1.1
+pylint==2.12.2

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,31 @@
+[tox]
+envlist = py38, py39, py310, lint, mypy
+skip_missing_interpreters = True
+
+[gh-actions]
+python =
+  3.8: py38, lint, mypy
+  3.9: py39
+  3.10: py310
+
+[testenv:lint]
+basepython = python3
+ignore_errors = True
+commands =
+  black --check ./
+  flake8 aiowebostv
+  isort aiowebostv
+  pylint aiowebostv
+  pydocstyle aiowebostv
+deps =
+  -rrequirements.txt
+  -rrequirements_lint.txt
+
+[testenv:mypy]
+basepython = python3
+ignore_errors = True
+commands =
+  mypy aiowebostv
+deps =
+  -rrequirements.txt
+  -rrequirements_lint.txt


### PR DESCRIPTION
Based on templates from https://github.com/home-assistant-libs/zwave-js-server-python
- Add GitHub CI workflow using `tox`
- Update `pre-commit` dependencies to match the ones used by `tox`
- Add `pydocstyle` and `mypy` hook to `pre-commit`
- Fix `pydocstyle` and `pylint` errors
