### PR TITLE
Fix websockets client connect import error

### DIFF
--- a/aiowebostv/webos_client.py
+++ b/aiowebostv/webos_client.py
@@ -7,6 +7,7 @@ import os
 from datetime import timedelta
 
 import websockets
+from websockets.client import connect as ws_connect
 
 from . import endpoints as ep
 from .exceptions import (
@@ -99,7 +100,7 @@ class WebOsClient:
         input_ws = None
         try:
             main_ws = await asyncio.wait_for(
-                websockets.client.connect(
+                ws_connect(
                     f"ws://{self.host}:{self.port}",
                     ping_interval=None,
                     close_timeout=self.timeout_connect,
@@ -159,7 +160,7 @@ class WebOsClient:
             sockres = await self.request(ep.INPUT_SOCKET)
             inputsockpath = sockres.get("socketPath")
             input_ws = await asyncio.wait_for(
-                websockets.client.connect(
+                ws_connect(
                     inputsockpath,
                     ping_interval=None,
                     close_timeout=self.timeout_connect,

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     long_description_content_type="text/markdown",
     packages=["aiowebostv"],
     python_requires=">=3.8",
-    install_requires=["websockets>=8.1"],
+    install_requires=["websockets>=9.1"],
     include_package_data=True,
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
While working on the core integration I encountered the following error:
```txt
  File "/workspaces/core/homeassistant/components/webostv/__init__.py", line 270, in connect
    await self.client.connect()
  File "/usr/local/lib/python3.9/site-packages/aiowebostv/webos_client.py", line 69, in connect
    return await self.connect_result
  File "/usr/local/lib/python3.9/site-packages/aiowebostv/webos_client.py", line 102, in connect_handler
    websockets.client.connect(
  File "/usr/local/lib/python3.9/site-packages/websockets/imports.py", line 96, in __getattr__
    raise AttributeError(f"module {package!r} has no attribute {name!r}")
AttributeError: module 'websockets' has no attribute 'client'
```
I find out core pin the `websockets` requirement to 9.1 due to a bug (which is already resolved): https://github.com/home-assistant/core/pull/58626

The change from `websockets.connect` to `websockets.client.connect` was made in https://github.com/home-assistant-libs/aiowebostv/pull/5 in order to pass lint, however it will only work at runtime using `websockets>=10.0`

The situation with 9.x releases is that either it fails linting when using `websockets.connect` or fails runtime when using `websockets.client.connect` (note: it fails even if linting is pinned to use 9.1 and not 10.1 as it is now)

Although we can remove the pin in core for 9.1 the package is actually broken when `websockets` version is 9.1

From the original issue https://github.com/aaugustin/websockets/issues/940 I used a workaround that will work from any 9.x release and above so even if we don't pin `websockets` to 9.1 it will still work.
