### PR TITLE
Add communication logging

### DIFF
--- a/aiowebostv/webos_client.py
+++ b/aiowebostv/webos_client.py
@@ -210,7 +210,7 @@ class WebOsClient:
             await asyncio.wait(handler_tasks, return_when=asyncio.FIRST_COMPLETED)
 
         except Exception as ex:  # pylint: disable=broad-except
-            _LOGGER.debug("exception(%s): %s", self.host, repr(ex), exc_info=True)
+            _LOGGER.debug("exception(%s): %r", self.host, ex, exc_info=True)
             if not res.done():
                 res.set_exception(ex)
         finally:
@@ -259,25 +259,6 @@ class WebOsClient:
                         await asyncio.shield(closeout_task)
                     except asyncio.CancelledError:
                         pass
-
-    async def ping_handler(self, web_socket, interval, timeout):
-        """Ping Handler loop."""
-        try:
-            while True:
-                await asyncio.sleep(interval)
-                # In the "Suspend" state the tv can keep a connection alive,
-                # but will not respond to pings
-                if self._power_state.get("state") != "Suspend":
-                    ping_waiter = await web_socket.ping()
-                    if timeout is not None:
-                        await asyncio.wait_for(ping_waiter, timeout=timeout)
-        except (
-            asyncio.TimeoutError,
-            asyncio.CancelledError,
-            websockets.exceptions.ConnectionClosedError,
-            websockets.exceptions.ConnectionClosedOK,
-        ):
-            pass
 
     @staticmethod
     async def callback_handler(queue, callback, future):


### PR DESCRIPTION
Add basic low level communication logging to allow debug situations that we loose sync with the TV state until restart.
Notes:
- Logging is not meant to be user friendly, mostly developer friendly.
- Since registration messages contain the pairing secret key and we currently don't have issues with pairing, they are only logged as `registration` to indicate that they happen.

Example log output:
```
2022-02-12 00:14:01 DEBUG (MainThread) [aiowebostv] send(192.168.1.39): hello
2022-02-12 00:14:01 DEBUG (MainThread) [aiowebostv] recv(192.168.1.39): {"type":"hello","payload":{"protocolVersion":1,"deviceType":"tv","deviceOS":"webOS","deviceOSVersion":"4.1.0","deviceOSReleaseVersion":"4.4.0","deviceUUID":"2f254315-afbe-12dd-3be5-71e3b1b68fe3","pairingTypes":["PIN","PROMPT","COMBINED"]}}
2022-02-12 00:14:01 DEBUG (MainThread) [aiowebostv] send(192.168.1.39): registration
2022-02-12 00:14:01 DEBUG (MainThread) [aiowebostv] recv(192.168.1.39): registration
2022-02-12 00:14:01 DEBUG (MainThread) [aiowebostv] send(192.168.1.39): {'id': 0, 'type': 'request', 'uri': 'ssap://com.webos.service.networkinput/getPointerInputSocket', 'payload': {}}
2022-02-12 00:14:01 DEBUG (MainThread) [aiowebostv] recv(192.168.1.39): {"type":"response","id":0,"payload":{"socketPath":"ws://192.168.1.39:3000/resources/c7fe6679da4a34fb5748e6477fb314696bb5afd2/netinput.pointer.sock","returnValue":true}}
2022-02-12 00:14:01 DEBUG (MainThread) [aiowebostv] send(192.168.1.39): {'id': 1, 'type': 'request', 'uri': 'ssap://system/getSystemInfo', 'payload': {}}
2022-02-12 00:14:01 DEBUG (MainThread) [aiowebostv] send(192.168.1.39): {'id': 2, 'type': 'request', 'uri': 'ssap://com.webos.service.update/getCurrentSWInformation', 'payload': {}}
2022-02-12 00:14:01 DEBUG (MainThread) [aiowebostv] recv(192.168.1.39): {"type":"response","id":1,"payload":{"returnValue":true,"features":{"3d":false,"dvr":true},"receiverType":"dvb","modelName":"55SK8500YVA","programMode":"true"}}
2022-02-12 00:14:01 DEBUG (MainThread) [aiowebostv] recv(192.168.1.39): {"type":"response","id":2,"payload":{"returnValue":true,"product_name":"webOSTV 4.0","model_name":"HE_DTV_W18H_AFADABAA","sw_type":"FIRMWARE","major_ver":"05","minor_ver":"40.09","country":"IL","country_group":"IL","device_id":"fe:23:aa:ae:1e:33","auth_flag":"N","ignore_disable":"N","eco_info":"01","config_key":"00","language_code":"he-IL"}}
```