### PR TITLE
Add delay before live TV channel subscription

### DIFF
--- a/aiowebostv/webos_client.py
+++ b/aiowebostv/webos_client.py
@@ -463,6 +463,7 @@ class WebOsClient:
                 pass
 
         if app_id == "com.webos.app.livetv" and self._current_channel is None:
+            await asyncio.sleep(2)
             try:
                 await self.subscribe_current_channel(self.set_current_channel_state)
             except WebOsTvCommandError:


### PR DESCRIPTION
When switching to live TV we try to subscribe updates for current channel, it seems that on some TVs doing this too fast before the live TV app is ready will break all future status updates, 1 second delay is enough, but to be on the safe side 2 seconds delay is added. This only happen once when switching to live TV.

This will fix https://github.com/home-assistant/core/issues/49453

Thanks @[Heisenberg2980](https://github.com/Heisenberg2980) for helping finding the root cause for this and helping with testing.
