### PR TITLE
Update pre-commit dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.3.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -17,17 +17,17 @@ repos:
           - --max-complexity=18
           - --select=B,C,E,F,W,T4,B9
   - repo: https://github.com/ambv/black
-    rev: 21.12b0
+    rev: 22.8.0
     hooks:
       - id: black
         language_version: python3
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.31.0
+    rev: v2.38.0
     hooks:
       - id: pyupgrade
         args: ["--py39-plus"]
-  - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.10.1
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.10.1
     hooks:
       - id: isort
         args:
@@ -41,6 +41,6 @@ repos:
     hooks:
       - id: pydocstyle
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v0.930"
+    rev: "v0.971"
     hooks:
       - id: mypy


### PR DESCRIPTION
## Update pre-commit dependencies:

- Resolves issue with old black:
```
black....................................................................Failed
- hook id: black
- exit code: 1

Traceback (most recent call last):
  File "C:\Program Files\Python310\lib\runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "C:\Program Files\Python310\lib\runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "C:\Users\Shayl\.cache\pre-commit\repoj02_f0pq\py_env-python3\Scripts\black.EXE\__main__.py", line 7, in <module>
  File "C:\Users\Shayl\.cache\pre-commit\repoj02_f0pq\py_env-python3\lib\site-packages\black\__init__.py", line 1372, in patched_main
    patch_click()
  File "C:\Users\Shayl\.cache\pre-commit\repoj02_f0pq\py_env-python3\lib\site-packages\black\__init__.py", line 1358, in patch_click
    from click import _unicodefun
ImportError: cannot import name '_unicodefun' from 'click' (C:\Users\Shayl\.cache\pre-commit\repoj02_f0pq\py_env-python3\lib\site-packages\click\__init__.py)
```

- Update isort repo which was using an archived repository
