### PR TITLE
Update websockets version to 10.3 for Python 3.10 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     long_description_content_type="text/markdown",
     packages=["aiowebostv"],
     python_requires=">=3.9",
-    install_requires=["websockets>=9.1"],
+    install_requires=["websockets>=10.3"],
     include_package_data=True,
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
**Update websockets minimum version to 10.3 for Python 3.10 support**

We dropped support for Python 3.8 in https://github.com/home-assistant-libs/aiowebostv/pull/24, however the current minimum `websockets` version does not support Python 3.10.
`websockets` 10.3 dropped support for Python 3.6 and added support for Python 3.10: https://github.com/aaugustin/websockets/pull/936

This will not be a breaking change for `aiowebsotv` and will ensure we support Python 3.10

Related to https://github.com/home-assistant/core/issues/78904
