### PR TITLE
Bump pre-commit dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,12 +17,12 @@ repos:
           - --max-complexity=18
           - --select=B,C,E,F,W,T4,B9
   - repo: https://github.com/ambv/black
-    rev: 22.8.0
+    rev: 22.10.0
     hooks:
       - id: black
         language_version: python3
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.38.0
+    rev: v3.2.0
     hooks:
       - id: pyupgrade
         args: ["--py39-plus"]
@@ -41,6 +41,28 @@ repos:
     hooks:
       - id: pydocstyle
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v0.971"
+    rev: "v0.982"
     hooks:
       - id: mypy
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.2
+    hooks:
+      - id: codespell
+        args:
+          - --skip="./.*,*.csv,*.json"
+          - --quiet-level=2
+        exclude_types: [csv, json]
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.7.4
+    hooks:
+      - id: bandit
+        args:
+          - --quiet
+          - --format=custom
+          - --configfile=bandit.yaml
+        files: ^aiowebostv/.+\.py$
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.7.1
+    hooks:
+      - id: prettier
+        stages: [manual]

--- a/bandit.yaml
+++ b/bandit.yaml
@@ -1,0 +1,21 @@
+# https://bandit.readthedocs.io/en/latest/config.html
+
+tests:
+  - B103
+  - B108
+  - B306
+  - B307
+  - B313
+  - B314
+  - B315
+  - B316
+  - B317
+  - B318
+  - B319
+  - B320
+  - B325
+  - B601
+  - B602
+  - B604
+  - B608
+  - B609

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -9,8 +9,7 @@ CLIENT_KEY = "140cce792ae045920e14da4daa414582"
 
 
 async def main():
-    """Basic webOS client example."""
-
+    """Webos client example."""
     client = WebOsClient(HOST, CLIENT_KEY)
     await client.connect()
 

--- a/examples/reconnect.py
+++ b/examples/reconnect.py
@@ -3,9 +3,10 @@ import asyncio
 from contextlib import suppress
 from datetime import datetime
 
+from websockets.exceptions import ConnectionClosed, ConnectionClosedOK
+
 from aiowebostv import WebOsClient
 from aiowebostv.exceptions import WebOsTvCommandError
-from websockets.exceptions import ConnectionClosed, ConnectionClosedOK
 
 WEBOSTV_EXCEPTIONS = (
     OSError,

--- a/examples/state_updates.py
+++ b/examples/state_updates.py
@@ -27,7 +27,7 @@ async def on_state_change(client):
 
 
 async def main():
-    """Subscribed State Updates Example."""
+    """Subscribe State Updates Example."""
     client = WebOsClient(HOST, CLIENT_KEY)
     await client.register_state_update_callback(on_state_change)
     await client.connect()


### PR DESCRIPTION
- Bump pre-commit dependencies to latest ones
- Add `codespell`, `bandit` & `prettier` (similar to https://github.com/home-assistant-libs/aioshelly)
- Fix failures from running on all files (`pre-commit run --all-files`)
