### PR TITLE
Fix pairing check

### DIFF
--- a/aiowebostv/webos_client.py
+++ b/aiowebostv/webos_client.py
@@ -156,6 +156,14 @@ class WebOsClient:
                 raw_response = await main_ws.recv()
                 _LOGGER.debug("recv(%s): pairing", self.host)
                 response = json.loads(raw_response)
+                _LOGGER.debug(
+                    "pairing(%s): type: %s, error: %s",
+                    self.host,
+                    response["type"],
+                    response.get("error"),
+                )
+                if response["type"] == "error":
+                    raise WebOsTvPairError(response["error"])
                 if response["type"] == "registered":
                     self.client_key = response["payload"]["client-key"]
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 PROJECT_DIR = Path(__file__).parent.resolve()
 README_FILE = PROJECT_DIR / "README.md"
-VERSION = "0.3.1"
+VERSION = "0.3.2"
 
 
 setup(


### PR DESCRIPTION
Working on reauth I noticed that if the client is supplied with a key but it is not accepted by the TV we don't raise since the current check is based only on the key:
https://github.com/home-assistant-libs/aiowebostv/blob/56dcad600385cd74a9114c35bd564dfb387411ac/aiowebostv/webos_client.py#L170-L171

If the user denied pairing (or did not answer after timeout) the TV will respond with:
`{'type': 'error', 'id': 'register_0', 'error': '403 User denied access', 'payload': {}}`
and we stay with the old key but we should raise since the key is invalid.
