### PR TITLE
Add missing async task creation when updating callbacks

### DIFF
--- a/aiowebostv/webos_client.py
+++ b/aiowebostv/webos_client.py
@@ -266,7 +266,7 @@ class WebOsClient:
             self._sound_output = None
 
             for callback in self.state_update_callbacks:
-                closeout.add(callback(self))
+                closeout.add(asyncio.create_task(callback(self)))
 
             if closeout:
                 closeout_task = asyncio.create_task(asyncio.wait(closeout))


### PR DESCRIPTION
This is based on the discussion made in #142 so I hope this change enables the use of the add-on with python3.11.

I tested this change using the example in the README and my LG WebOS TV with python 3.11.3 in Mac OS.

It tries to fix #142.