### PR TITLE
Update examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ if __name__ == "__main__":
 ### Subscribed State Updates Example:
 ```python
 import asyncio
+import signal
 
 from aiowebostv import WebOsClient
 
@@ -89,8 +90,10 @@ async def main():
     # Store this key for future use
     print(f"Client key: {client.client_key}")
 
-    # Change something using the remote during sleep period to get updates
-    await asyncio.sleep(30)
+    # Change something using the remote to get updates or ctrl-c to exit
+    sig_event = asyncio.Event()
+    signal.signal(signal.SIGINT, lambda _exit_code, _frame: sig_event.set())
+    await sig_event.wait()
 
     await client.disconnect()
 

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,0 +1,1 @@
+"""Examples for aiowebostv."""

--- a/examples/state_updates.py
+++ b/examples/state_updates.py
@@ -1,6 +1,7 @@
 """Subscribed state updates example."""
 
 import asyncio
+import signal
 
 from aiowebostv import WebOsClient
 
@@ -36,8 +37,10 @@ async def main():
     # Store this key for future use
     print(f"Client key: {client.client_key}")
 
-    # Change something using the remote during sleep period to get updates
-    await asyncio.sleep(30)
+    # Change something using the remote to get updates or ctrl-c to exit
+    sig_event = asyncio.Event()
+    signal.signal(signal.SIGINT, lambda _exit_code, _frame: sig_event.set())
+    await sig_event.wait()
 
     await client.disconnect()
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -29,7 +29,5 @@ lint.ignore = [
 
 [lint.per-file-ignores]
 "examples/*" = [
-    "DTZ005",    # `datetime.datetime.now()` called without a `tz` argument
-    "INP001",    # File is part of an implicit namespace package. Add an `__init__.py`.
     "T201",      # `print` found
 ]


### PR DESCRIPTION
Update examples to allow cleaner exit to verify disconnect is run correctly.

- Fix ignored ruff rules
- Change state updates example to run until `ctrl-c` instead of 30 seconds
- Fix reconnect example to run disconnect upon exit