### PR TITLE
Remove "Smart" from issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: true
 contact_links:
-  - name: Report a bug with LG webOS Smart TV
+  - name: Report a bug with LG webOS TV
     url: https://github.com/home-assistant/core/issues
-    about: Please report issues with LG webOS Smart TV in the Home Assistant core repository unless a developer told you otherwise.
+    about: Please report issues with LG webOS TV in the Home Assistant core repository unless a developer told you otherwise.
   - name: I have a question or need support
     url: https://www.home-assistant.io/help
     about: We use GitHub for tracking bugs, check the Home Assistant website for resources on getting help.


### PR DESCRIPTION
Remove "Smart" from the issue template to match the updated integration name
https://github.com/home-assistant/home-assistant.io/blob/aed501258731f86866ccd72bf0a7ed213ff58605/source/_integrations/webostv.markdown?plain=1#L2