### PR TITLE
Migrate to aiohttp

### DIFF
--- a/aiowebostv/webos_client.py
+++ b/aiowebostv/webos_client.py
@@ -332,7 +332,6 @@ class WebOsClient:
 
                 if callbacks or futures:
                     _LOGGER.debug("recv(%s): %s", self.host, raw_msg)
-
                     msg = json.loads(raw_msg.data)
                     uid = msg.get("id")
                     callback = self.callbacks.get(uid)

--- a/examples/reconnect.py
+++ b/examples/reconnect.py
@@ -5,16 +5,14 @@ import signal
 from contextlib import suppress
 from datetime import UTC, datetime
 
-from websockets.exceptions import ConnectionClosed, ConnectionClosedOK
+from aiohttp import ServerDisconnectedError
 
 from aiowebostv import WebOsClient
 from aiowebostv.exceptions import WebOsTvCommandError
 
 WEBOSTV_EXCEPTIONS = (
-    OSError,
-    ConnectionClosed,
-    ConnectionClosedOK,
-    ConnectionRefusedError,
+    ServerDisconnectedError,
+    ConnectionResetError,
     WebOsTvCommandError,
     asyncio.TimeoutError,
     asyncio.CancelledError,

--- a/examples/reconnect.py
+++ b/examples/reconnect.py
@@ -5,17 +5,18 @@ import signal
 from contextlib import suppress
 from datetime import UTC, datetime
 
-from aiohttp import ServerDisconnectedError
+import aiohttp
 
 from aiowebostv import WebOsClient
 from aiowebostv.exceptions import WebOsTvCommandError
 
 WEBOSTV_EXCEPTIONS = (
-    ServerDisconnectedError,
     ConnectionResetError,
     WebOsTvCommandError,
-    asyncio.TimeoutError,
+    aiohttp.ClientConnectorError,
+    aiohttp.ServerDisconnectedError,
     asyncio.CancelledError,
+    asyncio.TimeoutError,
 )
 
 HOST = "192.168.1.39"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-websockets==13.1
+aiohttp==3.11.11

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     packages=["aiowebostv"],
     python_requires=">=3.11",
     package_data={"aiowebostv": ["py.typed"]},
-    install_requires=["websockets>=10.3"],
+    install_requires=["aiohttp>=3.11"],
     include_package_data=True,
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
Replace `websockets` dependency with `aiohttp` add optional `ClientSession` parameter

### Breaking changes:
Class init parameters changed (all are optional mostly should not be used):
- `timeout_connect` changed to `connect_timeout`
- `ping_interval` changed to `heartbeat`
- `ping_timeout` removed
