### PR TITLE
Fix Ruff PTH12X

### DIFF
--- a/aiowebostv/webos_client.py
+++ b/aiowebostv/webos_client.py
@@ -5,12 +5,12 @@ import base64
 import copy
 import json
 import logging
-import os
 from asyncio import Future, Task
 from asyncio.queues import Queue
 from collections.abc import Callable
 from contextlib import suppress
 from datetime import timedelta
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 import aiohttp
@@ -724,8 +724,9 @@ class WebOsClient:
 
     def read_icon(self, icon_path: str, message_payload: dict[str, Any]) -> None:
         """Read icon & set data in message payload."""
-        message_payload["iconExtension"] = os.path.splitext(icon_path)[1][1:]
-        with open(icon_path, "rb") as icon_file:
+        path = Path(icon_path)
+        message_payload["iconExtension"] = path.suffix[1:]
+        with path.open("rb") as icon_file:
             message_payload["iconData"] = base64.b64encode(icon_file.read()).decode(
                 "ascii"
             )

--- a/ruff.toml
+++ b/ruff.toml
@@ -13,8 +13,6 @@ lint.ignore = [
     "ISC001",   # Single line implicit string concatenation
     "PLR0912",  # Too many branches
     "PLR0915",  # Too many statements
-    "PTH122",   # `os.path.splitext()` should be replaced by `Path.suffix`, `Path.stem`, and `Path.parent`
-    "PTH123",   # `open()` should be replaced by `Path.open()`
     "TRY003",   # Avoid specifying long messages outside the exception class
     "TRY301",   # Abstract `raise` to an inner function
 ]


### PR DESCRIPTION
Fix Ruff:
- "PTH122",   # `os.path.splitext()` should be replaced by `Path.suffix`, `Path.stem`, and `Path.parent`
- "PTH123",   # `open()` should be replaced by `Path.open()`
