### PR TITLE
Add WebOsTvInfo and WebOsTvState models; update examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ pip install --upgrade .
 ### Basic Example:
 ```python
 import asyncio
+from pprint import pprint
 
 from aiowebostv import WebOsClient
 
@@ -40,9 +41,8 @@ async def main():
     # Store this key for future use
     print(f"Client key: {client.client_key}")
 
-    apps = await client.get_apps_all()
-    for app in apps:
-        print(app)
+    pprint(client.tv_info)
+    pprint(client.tv_state)
 
     await client.disconnect()
 
@@ -54,31 +54,26 @@ if __name__ == "__main__":
 ### Subscribed State Updates Example:
 ```python
 import asyncio
+import dataclasses
 import signal
+from datetime import UTC, datetime
+from pprint import pprint
 
 from aiowebostv import WebOsClient
+from aiowebostv.models import WebOsTvState
 
 HOST = "192.168.1.39"
 # For first time pairing set key to None
 CLIENT_KEY = "140cce792ae045920e14da4daa414582"
 
 
-async def on_state_change(client):
+async def on_state_change(tv_state: WebOsTvState) -> None:
     """State changed callback."""
-    print("State changed:")
-    print(f"System info: {client.system_info}")
-    print(f"Software info: {client.software_info}")
-    print(f"Hello info: {client.hello_info}")
-    print(f"Channel info: {client.channel_info}")
-    print(f"Apps: {client.apps}")
-    print(f"Inputs: {client.inputs}")
-    print(f"Powered on: {client.power_state}")
-    print(f"App Id: {client.current_app_id}")
-    print(f"Channels: {client.channels}")
-    print(f"Current channel: {client.current_channel}")
-    print(f"Muted: {client.muted}")
-    print(f"Volume: {client.volume}")
-    print(f"Sound output: {client.sound_output}")
+    now = datetime.now(UTC).astimezone().strftime("%H:%M:%S.%f")[:-3]
+    print(f"[{now}] State change:")
+    # for the example, remove apps and inputs to make the output more readable
+    state = dataclasses.replace(tv_state, apps={}, inputs={})
+    pprint(state)
 
 
 async def main():

--- a/aiowebostv/__init__.py
+++ b/aiowebostv/__init__.py
@@ -1,6 +1,13 @@
 """Provide a package for controlling LG webOS based TVs."""
 
 from .exceptions import WebOsTvCommandError, WebOsTvPairError
+from .models import WebOsTvInfo, WebOsTvState
 from .webos_client import WebOsClient
 
-__all__ = ["WebOsClient", "WebOsTvCommandError", "WebOsTvPairError"]
+__all__ = [
+    "WebOsClient",
+    "WebOsTvCommandError",
+    "WebOsTvInfo",
+    "WebOsTvPairError",
+    "WebOsTvState",
+]

--- a/aiowebostv/models.py
+++ b/aiowebostv/models.py
@@ -3,16 +3,14 @@
 from dataclasses import MISSING, dataclass, field, fields
 from typing import Any
 
-WebOsTvStateValue = dict[str, Any] | str | bool | int | list[dict[str, Any]] | None
-
 
 @dataclass
 class WebOsTvInfo:
     """Represent LG webOS TV info."""
 
-    hello: dict[str, Any] = field(default_factory=dict[str, Any])
-    system: dict[str, Any] = field(default_factory=dict[str, Any])
-    software: dict[str, Any] = field(default_factory=dict[str, Any])
+    hello: dict[str, Any] = field(default_factory=dict)
+    system: dict[str, Any] = field(default_factory=dict)
+    software: dict[str, Any] = field(default_factory=dict)
 
     def clear(self) -> None:
         """Reset all fields to their default values."""

--- a/aiowebostv/models.py
+++ b/aiowebostv/models.py
@@ -39,26 +39,7 @@ class WebOsTvState:
     channels: list[dict[str, Any]] | None = None
     # Calculated fields
     is_on: bool = False
-    is_screen_on: bool | None = None
-
-    def __setattr__(self, name: str, value: WebOsTvStateValue) -> None:
-        """Update is_on & is_screen_on when power_state/current_app_id changes.
-
-        is_on fallback to current_app_id for older webos versions
-        which don't support explicit power state
-        """
-        super().__setattr__(name, value)  # Set the actual field
-
-        # Update calculated fields
-        if name in ["power_state", "current_app_id"]:
-            is_on = bool(self.current_app_id)
-            is_screen_on = None
-            if state := self.power_state.get("state"):
-                is_on = state not in ["Power Off", "Suspend", "Active Standby"]
-                is_screen_on = is_on and state != "Screen Off"
-
-            super().__setattr__("is_on", is_on)
-            super().__setattr__("is_screen_on", is_screen_on)
+    is_screen_on: bool = False
 
     def clear(self) -> None:
         """Reset all fields to their default values."""

--- a/aiowebostv/models.py
+++ b/aiowebostv/models.py
@@ -1,0 +1,72 @@
+"""LG webOS TV models."""
+
+from dataclasses import MISSING, dataclass, field, fields
+from typing import Any
+
+WebOsTvStateValue = dict[str, Any] | str | bool | int | list[dict[str, Any]] | None
+
+
+@dataclass
+class WebOsTvInfo:
+    """Represent LG webOS TV info."""
+
+    hello: dict[str, Any] = field(default_factory=dict[str, Any])
+    system: dict[str, Any] = field(default_factory=dict[str, Any])
+    software: dict[str, Any] = field(default_factory=dict[str, Any])
+
+    def clear(self) -> None:
+        """Reset all fields to their default values."""
+        for f in fields(self):
+            if f.default_factory is not MISSING:
+                setattr(self, f.name, f.default_factory())
+
+
+@dataclass
+class WebOsTvState:
+    """Represent the state of a LG webOS TV."""
+
+    power_state: dict[str, Any] = field(default_factory=dict[str, Any])
+    current_app_id: str | None = None
+    sound_output: str | None = None
+    muted: bool | None = None
+    volume: int | None = None
+    apps: dict[str, Any] = field(default_factory=dict[str, Any])
+    inputs: dict[str, Any] = field(default_factory=dict[str, Any])
+    media_state: list[dict[str, Any]] = field(default_factory=list[dict[str, Any]])
+    # Can't be empty dict, None is used to check if we need to subscribe to updates
+    current_channel: dict[str, Any] | None = None
+    channel_info: dict[str, Any] | None = None
+    channels: list[dict[str, Any]] | None = None
+    # Calculated fields
+    is_on: bool = False
+    is_screen_on: bool | None = None
+
+    def __setattr__(self, name: str, value: WebOsTvStateValue) -> None:
+        """Update is_on & is_screen_on when power_state/current_app_id changes.
+
+        is_on fallback to current_app_id for older webos versions
+        which don't support explicit power state
+        """
+        super().__setattr__(name, value)  # Set the actual field
+
+        # Update calculated fields
+        if name in ["power_state", "current_app_id"]:
+            is_on = bool(self.current_app_id)
+            is_screen_on = None
+            if state := self.power_state.get("state"):
+                is_on = state not in ["Power Off", "Suspend", "Active Standby"]
+                is_screen_on = is_on and state != "Screen Off"
+
+            super().__setattr__("is_on", is_on)
+            super().__setattr__("is_screen_on", is_screen_on)
+
+    def clear(self) -> None:
+        """Reset all fields to their default values."""
+        for f in fields(self):
+            # Reset to default value or default factory
+            if f.default is not MISSING:
+                setattr(self, f.name, f.default)
+            elif f.default_factory is not MISSING:
+                setattr(self, f.name, f.default_factory())
+            else:
+                setattr(self, f.name, None)

--- a/aiowebostv/models.py
+++ b/aiowebostv/models.py
@@ -25,14 +25,14 @@ class WebOsTvInfo:
 class WebOsTvState:
     """Represent the state of a LG webOS TV."""
 
-    power_state: dict[str, Any] = field(default_factory=dict[str, Any])
+    power_state: dict[str, Any] = field(default_factory=dict)
     current_app_id: str | None = None
     sound_output: str | None = None
     muted: bool | None = None
     volume: int | None = None
-    apps: dict[str, Any] = field(default_factory=dict[str, Any])
-    inputs: dict[str, Any] = field(default_factory=dict[str, Any])
-    media_state: list[dict[str, Any]] = field(default_factory=list[dict[str, Any]])
+    apps: dict[str, Any] = field(default_factory=dict)
+    inputs: dict[str, Any] = field(default_factory=dict)
+    media_state: list[dict[str, Any]] = field(default_factory=list)
     # Can't be empty dict, None is used to check if we need to subscribe to updates
     current_channel: dict[str, Any] | None = None
     channel_info: dict[str, Any] | None = None

--- a/aiowebostv/webos_client.py
+++ b/aiowebostv/webos_client.py
@@ -25,6 +25,7 @@ from .exceptions import (
     WebOsTvServiceNotFoundError,
 )
 from .handshake import REGISTRATION_MESSAGE
+from .models import WebOsTvInfo, WebOsTvState
 
 CONNECT_TIMEOUT = 2  # Timeout for connecting to the TV
 RECEIVE_TIMEOUT = 10  # Timeout for receiving messages using ws.receive_json
@@ -67,25 +68,13 @@ class WebOsClient:
         self.connection: ClientWebSocketResponse | None = None
         self.input_connection: ClientWebSocketResponse | None = None
         self.futures: dict[int, Future[dict[str, Any]]] = {}
-        self._power_state: dict[str, Any] = {}
-        self._current_app_id: str | None = None
-        self._muted: bool | None = None
-        self._volume: int | None = None
-        self._current_channel: dict[str, Any] | None = None
-        self._channel_info: dict[str, Any] | None = None
-        self._channels: list[dict[str, Any]] | None = None
-        self._apps: dict[str, Any] = {}
-        self._extinputs: dict[str, Any] = {}
-        self._system_info: dict[str, Any] = {}
-        self._software_info: dict[str, Any] = {}
-        self._hello_info: dict[str, Any] = {}
-        self._sound_output: str | None = None
+        self.tv_state = WebOsTvState()
+        self.tv_info = WebOsTvInfo()
         self.state_update_callbacks: list[Callable] = []
         self.do_state_update = False
         self._volume_step_lock = asyncio.Lock()
         self._volume_step_delay: timedelta | None = None
         self._loop = asyncio.get_running_loop()
-        self._media_state: list[dict[str, Any]] = []
         self.callback_queues: dict[int, Queue[dict[str, Any]]] = {}
         self.callback_tasks: dict[int, Task] = {}
         self._rx_tasks: set[Task] = set()
@@ -178,7 +167,7 @@ class WebOsClient:
         _LOGGER.debug("recv(%s): %s", self.host, response)
 
         if response["type"] == "hello":
-            self._hello_info = response["payload"]
+            self.tv_info.hello = response["payload"]
         else:
             error = f"Invalid response type {response}"
             raise WebOsTvCommandError(error)
@@ -228,7 +217,7 @@ class WebOsClient:
         Avoid partial updates during initial subscription.
         """
         self.do_state_update = False
-        self._system_info, self._software_info = await asyncio.gather(
+        self.tv_info.system, self.tv_info.software = await asyncio.gather(
             self.get_system_info(), self.get_software_info()
         )
         subscribe_state_updates = {
@@ -248,29 +237,8 @@ class WebOsClient:
         for task in subscribe_tasks:
             with suppress(WebOsTvServiceNotFoundError):
                 task.result()
-        # set placeholder power state if not available
-        if not self._power_state:
-            self._power_state = {"state": "Unknown"}
         self.do_state_update = True
-        if self.state_update_callbacks:
-            await self.do_state_update_callbacks()
-
-    def _clear_tv_states(self) -> None:
-        """Clear all TV states."""
-        self._power_state = {}
-        self._current_app_id = None
-        self._muted = None
-        self._volume = None
-        self._current_channel = None
-        self._channel_info = None
-        self._channels = None
-        self._apps = {}
-        self._extinputs = {}
-        self._system_info = {}
-        self._software_info = {}
-        self._hello_info = {}
-        self._sound_output = None
-        self._media_state = []
+        await self.do_state_update_callbacks()
 
     def _cancel_tasks(self) -> None:
         """Cancel all tasks."""
@@ -310,10 +278,10 @@ class WebOsClient:
         self.connection = None
         self.input_connection = None
         self.do_state_update = False
-        self._clear_tv_states()
+        self.tv_state.clear()
 
         for callback in self.state_update_callbacks:
-            closeout.add(asyncio.create_task(callback(self)))
+            closeout.add(asyncio.create_task(callback(self.tv_state)))
 
         if not closeout:
             return
@@ -329,6 +297,7 @@ class WebOsClient:
         self.callback_queues = {}
         self.callback_tasks = {}
         self.futures = {}
+        self.tv_info.clear()
         main_ws: ClientWebSocketResponse | None = None
         input_ws: ClientWebSocketResponse | None = None
         self._ensure_client_session()
@@ -403,100 +372,13 @@ class WebOsClient:
             if raw_msg.type is not WSMsgType.TEXT:
                 break
 
-    # manage state
-    @property
-    def power_state(self) -> dict[str, Any]:
-        """Return TV power state."""
-        return self._power_state
-
-    @property
-    def current_app_id(self) -> str | None:
-        """Return current TV App Id."""
-        return self._current_app_id
-
-    @property
-    def muted(self) -> bool | None:
-        """Return true if TV is muted."""
-        return self._muted
-
-    @property
-    def volume(self) -> int | None:
-        """Return current TV volume level."""
-        return self._volume
-
-    @property
-    def current_channel(self) -> dict[str, Any] | None:
-        """Return current TV channel."""
-        return self._current_channel
-
-    @property
-    def channel_info(self) -> dict[str, Any] | None:
-        """Return current channel info."""
-        return self._channel_info
-
-    @property
-    def channels(self) -> list[dict[str, Any]] | None:
-        """Return channel list."""
-        return self._channels
-
-    @property
-    def apps(self) -> dict[str, Any]:
-        """Return apps list."""
-        return self._apps
-
-    @property
-    def inputs(self) -> dict[str, Any]:
-        """Return external inputs list."""
-        return self._extinputs
-
-    @property
-    def system_info(self) -> dict[str, Any]:
-        """Return TV system info."""
-        return self._system_info
-
-    @property
-    def software_info(self) -> dict[str, Any]:
-        """Return TV software info."""
-        return self._software_info
-
-    @property
-    def hello_info(self) -> dict[str, Any]:
-        """Return TV hello info."""
-        return self._hello_info
-
-    @property
-    def sound_output(self) -> str | None:
-        """Return TV sound output."""
-        return self._sound_output
-
-    @property
-    def is_on(self) -> bool:
-        """Return true if TV is powered on."""
-        state = self._power_state.get("state")
-        if state == "Unknown":
-            # fallback to current app id for some older webos versions
-            # which don't support explicit power state
-            return self._current_app_id not in [None, ""]
-
-        return state not in [None, "Power Off", "Suspend", "Active Standby"]
-
-    @property
-    def is_screen_on(self) -> bool:
-        """Return true if screen is on."""
-        if self.is_on:
-            return self._power_state.get("state") != "Screen Off"
-        return False
-
-    @property
-    def media_state(self) -> list[dict[str, Any]]:
-        """Return media player state."""
-        return self._media_state
-
-    async def register_state_update_callback(self, callback: Callable) -> None:
+    async def register_state_update_callback(
+        self, callback: Callable[[WebOsTvState], Any]
+    ) -> None:
         """Register user state update callback."""
         self.state_update_callbacks.append(callback)
         if self.do_state_update:
-            await callback(self)
+            await callback(self.tv_state)
 
     def set_volume_step_delay(self, step_delay_ms: float | None) -> None:
         """Set volume step delay in ms or None to disable step delay."""
@@ -506,7 +388,9 @@ class WebOsClient:
 
         self._volume_step_delay = timedelta(milliseconds=step_delay_ms)
 
-    def unregister_state_update_callback(self, callback: Callable) -> None:
+    def unregister_state_update_callback(
+        self, callback: Callable[[WebOsTvState], Any]
+    ) -> None:
         """Unregister user state update callback."""
         if callback in self.state_update_callbacks:
             self.state_update_callbacks.remove(callback)
@@ -517,15 +401,16 @@ class WebOsClient:
 
     async def do_state_update_callbacks(self) -> None:
         """Call user state update callback."""
-        if callbacks := {callback(self) for callback in self.state_update_callbacks}:
-            await asyncio.gather(*callbacks)
+        if not self.state_update_callbacks or not self.do_state_update:
+            return
+
+        callbacks = {cb(self.tv_state) for cb in self.state_update_callbacks}
+        await asyncio.gather(*callbacks)
 
     async def set_power_state(self, payload: dict[str, bool | str]) -> None:
         """Set TV power state callback."""
-        self._power_state = payload
-
-        if self.state_update_callbacks and self.do_state_update:
-            await self.do_state_update_callbacks()
+        self.tv_state.power_state = payload
+        await self.do_state_update_callbacks()
 
     async def set_current_app_state(self, app_id: str) -> None:
         """Set current app state variable.
@@ -535,40 +420,33 @@ class WebOsClient:
         succeed when Live TV is running and channel list subscription
         can only succeed after channels have been configured.
         """
-        self._current_app_id = app_id
+        self.tv_state.current_app_id = app_id
 
-        if self._channels is None:
+        if self.tv_state.channels is None:
             with suppress(WebOsTvCommandError):
                 await self.subscribe_channels(self.set_channels_state)
 
-        if app_id == "com.webos.app.livetv" and self._current_channel is None:
+        if app_id == "com.webos.app.livetv" and self.tv_state.current_channel is None:
             await asyncio.sleep(2)
             with suppress(WebOsTvCommandError):
                 await self.subscribe_current_channel(self.set_current_channel_state)
 
-        if self.state_update_callbacks and self.do_state_update:
-            await self.do_state_update_callbacks()
+        await self.do_state_update_callbacks()
 
     async def set_muted_state(self, muted: bool) -> None:  # noqa: FBT001
         """Set TV mute state callback."""
-        self._muted = muted
-
-        if self.state_update_callbacks and self.do_state_update:
-            await self.do_state_update_callbacks()
+        self.tv_state.muted = muted
+        await self.do_state_update_callbacks()
 
     async def set_volume_state(self, volume: int) -> None:
         """Set TV volume level callback."""
-        self._volume = volume
-
-        if self.state_update_callbacks and self.do_state_update:
-            await self.do_state_update_callbacks()
+        self.tv_state.volume = volume
+        await self.do_state_update_callbacks()
 
     async def set_channels_state(self, channels: list[dict[str, Any]]) -> None:
         """Set TV channels callback."""
-        self._channels = channels
-
-        if self.state_update_callbacks and self.do_state_update:
-            await self.do_state_update_callbacks()
+        self.tv_state.channels = channels
+        await self.do_state_update_callbacks()
 
     async def set_current_channel_state(self, channel: dict[str, Any]) -> None:
         """Set current channel state variable.
@@ -577,62 +455,53 @@ class WebOsClient:
         since that call may fail if channel information is not
         available when it's called.
         """
-        self._current_channel = channel
+        self.tv_state.current_channel = channel
 
-        if self._channel_info is None:
+        if self.tv_state.channel_info is None:
             with suppress(WebOsTvCommandError):
                 await self.subscribe_channel_info(self.set_channel_info_state)
 
-        if self.state_update_callbacks and self.do_state_update:
-            await self.do_state_update_callbacks()
+        await self.do_state_update_callbacks()
 
     async def set_channel_info_state(self, channel_info: dict[str, Any]) -> None:
         """Set TV channel info state callback."""
-        self._channel_info = channel_info
-
-        if self.state_update_callbacks and self.do_state_update:
-            await self.do_state_update_callbacks()
+        self.tv_state.channel_info = channel_info
+        await self.do_state_update_callbacks()
 
     async def set_apps_state(self, payload: dict[str, Any]) -> None:
         """Set TV channel apps state callback."""
         apps = payload.get("launchPoints")
         if apps is not None:
-            self._apps = {}
+            self.tv_state.apps = {}
             for app in apps:
-                self._apps[app["id"]] = app
+                self.tv_state.apps[app["id"]] = app
         else:
             change = payload["change"]
             app_id = payload["id"]
             if change == "removed":
-                del self._apps[app_id]
+                del self.tv_state.apps[app_id]
             else:
-                self._apps[app_id] = payload
+                self.tv_state.apps[app_id] = payload
 
-        if self.state_update_callbacks and self.do_state_update:
-            await self.do_state_update_callbacks()
+        await self.do_state_update_callbacks()
 
     async def set_inputs_state(self, extinputs: list[dict[str, Any]]) -> None:
         """Set TV inputs state callback."""
-        self._extinputs = {}
+        self.tv_state.inputs = {}
         for extinput in extinputs:
-            self._extinputs[extinput["appId"]] = extinput
+            self.tv_state.inputs[extinput["appId"]] = extinput
 
-        if self.state_update_callbacks and self.do_state_update:
-            await self.do_state_update_callbacks()
+        await self.do_state_update_callbacks()
 
     async def set_sound_output_state(self, sound_output: str) -> None:
         """Set TV sound output state callback."""
-        self._sound_output = sound_output
-
-        if self.state_update_callbacks and self.do_state_update:
-            await self.do_state_update_callbacks()
+        self.tv_state.sound_output = sound_output
+        await self.do_state_update_callbacks()
 
     async def set_media_state(self, foreground_app_info: list[dict[str, bool]]) -> None:
         """Set TV media player state callback."""
-        self._media_state = foreground_app_info
-
-        if self.state_update_callbacks and self.do_state_update:
-            await self.do_state_update_callbacks()
+        self.tv_state.media_state = foreground_app_info
+        await self.do_state_update_callbacks()
 
     # low level request handling
 
@@ -897,7 +766,7 @@ class WebOsClient:
 
         Protect against turning tv back on if it is off.
         """
-        if not self.is_on:
+        if not self.tv_state.is_on:
             return
 
         # if tv is shutting down and standby+ option is not enabled,
@@ -994,7 +863,8 @@ class WebOsClient:
         shouldn't be possible to perform immediately after.
         """
         if (
-            self.sound_output in SOUND_OUTPUTS_TO_DELAY_CONSECUTIVE_VOLUME_STEPS
+            self.tv_state.sound_output
+            in SOUND_OUTPUTS_TO_DELAY_CONSECUTIVE_VOLUME_STEPS
             and self._volume_step_delay is not None
         ):
             async with self._volume_step_lock:

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -1,6 +1,7 @@
 """Basic webOS client example."""
 
 import asyncio
+from pprint import pprint
 
 from aiowebostv import WebOsClient
 
@@ -17,9 +18,8 @@ async def main() -> None:
     # Store this key for future use
     print(f"Client key: {client.client_key}")
 
-    if (apps := await client.get_apps_all()) is not None:
-        for app in apps:
-            print(app)
+    pprint(client.tv_info)
+    pprint(client.tv_state)
 
     await client.disconnect()
 

--- a/examples/reconnect.py
+++ b/examples/reconnect.py
@@ -37,7 +37,7 @@ async def main() -> None:
 
         now = datetime.now(UTC).astimezone().strftime("%H:%M:%S.%f")[:-3]
         is_connected = client.is_connected()
-        is_on = client.is_on
+        is_on = client.tv_state.is_on
 
         print(f"[{now}] Connected: {is_connected}, Powered on: {is_on}")
 

--- a/examples/state_updates.py
+++ b/examples/state_updates.py
@@ -1,31 +1,26 @@
 """Subscribed state updates example."""
 
 import asyncio
+import dataclasses
 import signal
+from datetime import UTC, datetime
+from pprint import pprint
 
 from aiowebostv import WebOsClient
+from aiowebostv.models import WebOsTvState
 
 HOST = "192.168.1.39"
 # For first time pairing set key to None
 CLIENT_KEY = "140cce792ae045920e14da4daa414582"
 
 
-async def on_state_change(client: WebOsClient) -> None:
+async def on_state_change(tv_state: WebOsTvState) -> None:
     """State changed callback."""
-    print("State changed:")
-    print(f"System info: {client.system_info}")
-    print(f"Software info: {client.software_info}")
-    print(f"Hello info: {client.hello_info}")
-    print(f"Channel info: {client.channel_info}")
-    print(f"Apps: {client.apps}")
-    print(f"Inputs: {client.inputs}")
-    print(f"Powered on: {client.power_state}")
-    print(f"App Id: {client.current_app_id}")
-    print(f"Channels: {client.channels}")
-    print(f"Current channel: {client.current_channel}")
-    print(f"Muted: {client.muted}")
-    print(f"Volume: {client.volume}")
-    print(f"Sound output: {client.sound_output}")
+    now = datetime.now(UTC).astimezone().strftime("%H:%M:%S.%f")[:-3]
+    print(f"[{now}] State change:")
+    # for the example, remove apps and inputs to make the output more readable
+    state = dataclasses.replace(tv_state, apps={}, inputs={})
+    pprint(state)
 
 
 async def main() -> None:

--- a/ruff.toml
+++ b/ruff.toml
@@ -11,5 +11,6 @@ lint.ignore = [
 
 [lint.per-file-ignores]
 "examples/*" = [
-    "T201",      # `print` found
+    "T201",     # `print` found
+    "T203",     # `pprint` found
 ]


### PR DESCRIPTION
Introduction of new data models (`WebOsTvInfo` and `WebOsTvState`) and the refactoring of existing methods to utilize these models for better state handling.

### Refactoring and State Management Improvements:

* [`aiowebostv/models.py`](diffhunk://#diff-7e78e4ba1daab4c4167b700fd7ee8a01560fc5de2ac9f7c24c44a2c20e888774R1-R53): Added new data models `WebOsTvInfo` and `WebOsTvState` to represent TV information and state, respectively. These models include methods to reset their fields to default values.
* [`aiowebostv/webos_client.py`](diffhunk://#diff-f2e58189bbcf7b06b18ea42f1e7d83506a5630e361383303ec0f83490966ddabL70-L88): Refactored the `WebOsClient` class to use the new `WebOsTvInfo` and `WebOsTvState` models for managing TV state and information.

### Documentation Updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R26): Updated the basic example and subscribed state updates example to reflect the new state management approach.

### Breaking changes:
- The following properties moved to the `WebOsTvState` model (accessed via the `tv_state` property):
`power_state`, `current_app_id`, `muted`, `volume`, `current_channel`, `channel_info`, `channels`, `apps`, `inputs`, `sound_output`, `is_on`, `is_screen_on`, `media_state`.

- The following properties moved to the `WebOsTvInfo` model (accessed via the `tv_info` property):
`system_info`, `software_info`, `hello_info`

- State update callback uses `WebOsTvState` reference instead of `WebOsClient`