### PR TITLE
Implement timeout handling

### DIFF
--- a/aiowebostv/exceptions.py
+++ b/aiowebostv/exceptions.py
@@ -13,6 +13,10 @@ class WebOsTvCommandError(WebOsTvError):
     """Represent TV command errors."""
 
 
+class WebOsTvCommandTimeoutError(WebOsTvCommandError):
+    """Represent TV command timeout error."""
+
+
 class WebOsTvResponseTypeError(WebOsTvCommandError):
     """Represent TV responded with error type."""
 

--- a/aiowebostv/webos_client.py
+++ b/aiowebostv/webos_client.py
@@ -26,8 +26,9 @@ from .exceptions import (
 )
 from .handshake import REGISTRATION_MESSAGE
 
-CONNECT_TIMEOUT = 2
-RECEIVE_TIMEOUT = 10
+CONNECT_TIMEOUT = 2  # Timeout for connecting to the TV
+RECEIVE_TIMEOUT = 10  # Timeout for receiving messages using ws.receive_json
+REQUEST_TIMEOUT = 5  # Timeout for waiting for a response to a request
 
 HEARTBEAT = 5
 
@@ -681,7 +682,7 @@ class WebOsClient:
             res = self.futures[uid]
         try:
             await self.command(cmd_type, uri, payload, uid)
-            async with asyncio.timeout(RECEIVE_TIMEOUT):
+            async with asyncio.timeout(REQUEST_TIMEOUT):
                 response = await res
         except TimeoutError as err:
             error = f"Response timed out for {uri} with uid {uid}"

--- a/aiowebostv/webos_client.py
+++ b/aiowebostv/webos_client.py
@@ -28,7 +28,7 @@ from .handshake import REGISTRATION_MESSAGE
 
 CONNECT_TIMEOUT = 2  # Timeout for connecting to the TV
 RECEIVE_TIMEOUT = 10  # Timeout for receiving messages using ws.receive_json
-REQUEST_TIMEOUT = 5  # Timeout for waiting for a response to a request
+REQUEST_TIMEOUT = 20  # Timeout for waiting for a response to a request
 
 HEARTBEAT = 5
 

--- a/aiowebostv/webos_client.py
+++ b/aiowebostv/webos_client.py
@@ -19,11 +19,17 @@ from aiohttp import ClientSession, ClientWebSocketResponse, WSMsgType
 from . import endpoints as ep
 from .exceptions import (
     WebOsTvCommandError,
+    WebOsTvCommandTimeoutError,
     WebOsTvPairError,
     WebOsTvResponseTypeError,
     WebOsTvServiceNotFoundError,
 )
 from .handshake import REGISTRATION_MESSAGE
+
+CONNECT_TIMEOUT = 2
+RECEIVE_TIMEOUT = 10
+
+HEARTBEAT = 5
 
 SOUND_OUTPUTS_TO_DELAY_CONSECUTIVE_VOLUME_STEPS = {"external_arc"}
 
@@ -43,8 +49,8 @@ class WebOsClient:
         self,
         host: str,
         client_key: str | None = None,
-        connect_timeout: float = 2,
-        heartbeat: float = 5,
+        connect_timeout: float = CONNECT_TIMEOUT,
+        heartbeat: float = HEARTBEAT,
         client_session: ClientSession | None = None,
     ) -> None:
         """Initialize the client."""
@@ -167,7 +173,7 @@ class WebOsClient:
         """Get hello info."""
         _LOGGER.debug("send(%s): hello", self.host)
         await ws.send_json({"id": "hello", "type": "hello"})
-        response = await ws.receive_json()
+        response = await ws.receive_json(timeout=RECEIVE_TIMEOUT)
         _LOGGER.debug("recv(%s): %s", self.host, response)
 
         if response["type"] == "hello":
@@ -180,14 +186,14 @@ class WebOsClient:
         """Check if the client is registered with the tv."""
         _LOGGER.debug("send(%s): registration", self.host)
         await ws.send_json(self.registration_msg())
-        response = await ws.receive_json()
+        response = await ws.receive_json(timeout=RECEIVE_TIMEOUT)
         _LOGGER.debug("recv(%s): registration", self.host)
 
         if (
             response["type"] == "response"
             and response["payload"]["pairingType"] == "PROMPT"
         ):
-            response = await ws.receive_json()
+            response = await ws.receive_json(timeout=RECEIVE_TIMEOUT)
             _LOGGER.debug("recv(%s): pairing", self.host)
             _LOGGER.debug(
                 "pairing(%s): type: %s, error: %s",
@@ -675,18 +681,21 @@ class WebOsClient:
             res = self.futures[uid]
         try:
             await self.command(cmd_type, uri, payload, uid)
+            async with asyncio.timeout(RECEIVE_TIMEOUT):
+                response = await res
+        except TimeoutError as err:
+            error = f"Response timed out for {uri} with uid {uid}"
+            raise WebOsTvCommandTimeoutError(error) from err
         except (asyncio.CancelledError, WebOsTvCommandError):
+            raise
+        finally:
             del self.futures[uid]
-            raise
-        try:
-            response = await res
-        except asyncio.CancelledError:
-            if uid in self.futures:
-                del self.futures[uid]
-            raise
-        del self.futures[uid]
 
-        payload = response.get("payload")
+        return self._parse_response(response)
+
+    def _parse_response(self, response: dict[str, Any]) -> dict[str, Any]:
+        """Parse response."""
+        payload: dict[str, Any] | None = response.get("payload")
         if payload is None:
             error = f"Invalid request response {response}"
             raise WebOsTvCommandError(error)
@@ -698,7 +707,7 @@ class WebOsClient:
         )
 
         if response.get("type") == "error":
-            error = response.get("error")
+            error = response.get("error", "")
             if error == "404 no such service or method":
                 raise WebOsTvServiceNotFoundError(error)
             raise WebOsTvResponseTypeError(response)


### PR DESCRIPTION
Handles timeouts

### New Exception Class:
* [`aiowebostv/exceptions.py`](diffhunk://#diff-974bd4fdb5665c3279efba254e4753746e049b22097a34fe72164d4b68932151R16-R19): Added `WebOsTvCommandTimeoutError` class to represent TV command timeout errors.

### Default Timeout Values:
* [`aiowebostv/webos_client.py`](diffhunk://#diff-f2e58189bbcf7b06b18ea42f1e7d83506a5630e361383303ec0f83490966ddabR22-R33): Introduced `CONNECT_TIMEOUT`, `RECEIVE_TIMEOUT`, and `HEARTBEAT` constants for default timeout values.
* [`aiowebostv/webos_client.py`](diffhunk://#diff-f2e58189bbcf7b06b18ea42f1e7d83506a5630e361383303ec0f83490966ddabL46-R53): Updated `__init__` method to use the new default timeout values.

### Timeout Handling:
* [`aiowebostv/webos_client.py`](diffhunk://#diff-f2e58189bbcf7b06b18ea42f1e7d83506a5630e361383303ec0f83490966ddabL170-R176): Updated `_get_hello_info` and `_check_registration` methods to use `RECEIVE_TIMEOUT` for receiving JSON responses. 
* [`aiowebostv/webos_client.py`](diffhunk://#diff-f2e58189bbcf7b06b18ea42f1e7d83506a5630e361383303ec0f83490966ddabL678-R698): Modified `request` method to handle `TimeoutError` and raise `WebOsTvCommandTimeoutError` if a response times out.