### PR TITLE
Fix hello message payload

### DIFF
--- a/aiowebostv/webos_client.py
+++ b/aiowebostv/webos_client.py
@@ -163,7 +163,7 @@ class WebOsClient:
     async def _get_hello_info(self, ws: ClientWebSocketResponse) -> None:
         """Get hello info."""
         _LOGGER.debug("send(%s): hello", self.host)
-        await ws.send_json({"id": "hello", "type": "hello"})
+        await ws.send_json({"id": "hello", "type": "hello", "payload": {}})
         response = await ws.receive_json(timeout=RECEIVE_TIMEOUT)
         _LOGGER.debug("recv(%s): %s", self.host, response)
 


### PR DESCRIPTION
`hello` message was the only one missing payload key in the request, all other commands include the payload key even if there is no payload in the request.

New TV firmware (33.20.x) does not respond if there is no payload key in the hello request - https://github.com/home-assistant/core/issues/147557#issuecomment-3037415580, https://github.com/home-assistant/core/issues/147557#issuecomment-3038907985