### PR TITLE
Fix system info

### DIFF
--- a/aiowebostv/webos_client.py
+++ b/aiowebostv/webos_client.py
@@ -220,9 +220,15 @@ class WebOsClient:
         Avoid partial updates during initial subscription.
         """
         self.do_state_update = False
-        self.tv_info.system, self.tv_info.software = await asyncio.gather(
-            self.get_system_info(), self.get_software_info()
-        )
+
+        # Try to get system info; on newer webOS versions,
+        # this may fail because system info must be retrieved before registration.
+        if not self.tv_info.system:
+            with suppress(WebOsTvResponseTypeError):
+                self.tv_info.system = await self.get_system_info()
+
+        self.tv_info.software = await self.get_software_info()
+
         subscribe_state_updates = {
             self.subscribe_power_state(self.set_power_state),
             self.subscribe_current_app(self.set_current_app_state),


### PR DESCRIPTION
Fixes https://github.com/home-assistant/core/issues/147557
Thanks to @rcode6 for helping figuring out this change in newer TV firmware releases!

This pull request introduces changes to improve compatibility with newer versions of webOS by ensuring system information is retrieved before registration. 

### Compatibility improvements for newer webOS versions:

* **Added `_get_pre_reg_system_info` method:** Introduced a new method to retrieve system information before registration, which is required for newer webOS versions. This method sends a request for system info, processes the response, and updates the `tv_info.system` attribute.

* **Modified `_get_states_and_subscribe_state_updates` method:** Updated the logic to attempt fetching system information only if it hasn't already been retrieved during pre-registration, ensuring compatibility with newer and older webOS versions.

* **Updated `connect_handler` method:** Incorporated a call to the new `_get_pre_reg_system_info` method before the registration check to ensure system info is retrieved as required.