### PR TITLE
Expose information about TV MAC addresses

### DIFF
--- a/aiowebostv/endpoints.py
+++ b/aiowebostv/endpoints.py
@@ -55,6 +55,7 @@ TURN_OFF_SCREEN = "com.webos.service.tvpower/power/turnOffScreen"
 TURN_ON_SCREEN = "com.webos.service.tvpower/power/turnOnScreen"
 GET_CONFIGS = "config/getConfigs"
 GET_MEDIA_FOREGROUND_APP_INFO = "com.webos.media/getForegroundAppInfo"
+GET_CONNECTION_MACS = "com.webos.service.connectionmanager/getinfo"
 
 # webOS TV internal Luna API endpoints
 LUNA_SET_CONFIGS = "com.webos.service.config/setConfigs"

--- a/aiowebostv/webos_client.py
+++ b/aiowebostv/webos_client.py
@@ -269,6 +269,7 @@ class WebOsClient:
                 self.tv_info.system = await self.get_system_info()
 
         self.tv_info.software = await self.get_software_info()
+        self.tv_info.connection_macs = await self.get_connection_macs()
 
         subscribe_state_updates = {
             self.subscribe_power_state(self.set_power_state),
@@ -863,6 +864,10 @@ class WebOsClient:
     ) -> dict[str, Any]:
         """Return the system information."""
         return await self.request(ep.GET_SYSTEM_INFO)
+
+    async def get_connection_macs(self) -> dict[str, Any]:
+        """Return the MAC addresses of network interfaces."""
+        return await self.request(ep.GET_CONNECTION_MACS)
 
     async def power_off(self) -> None:
         """Power off TV.


### PR DESCRIPTION
I've tested this manually, locally, against my LG C5 OLED. Here's what `pprint(client.tv_info.connection_macs)` dumps out:

```
{'p2pInfo': {'macAddress': '0A:27:A8:9C:52:C8'},
 'returnValue': True,
 'subscribed': False,
 'wifiInfo': {'macAddress': '08:27:A8:9C:52:C8'},
 'wiredInfo': {'macAddress': '60:75:6C:27:A9:02'}}
```

I opted not to create a subscription for this data even though [according to the webOS OSS docs](https://www.webosose.org/docs/reference/ls2-api/com-webos-service-connectionmanager/#getinfo) this is possible simply for efficiency reasons - my TV isn't connected to WiFi, but returns a WiFi MAC address anyway, so I _assume_ that it's returning the static hardware MAC address, independent of whether an interface is actually up. So based on that assumption, it seems like a waste of resources on both ends to create a subscription.

I am **not confident** about error handling here. How do y'all handle testing on old webOS versions? I have no idea if this will be available in every version out there.

Some sleuthing to attempt to answer the compat question above: this API is not mentioned at all in the commercial/downstream LG webOS documentation: https://webostv.developer.lge.com/develop/references/connection-manager. _However_. According to [this chart](https://webostv.developer.lge.com/develop/references/luna-service-introduction#api-compatibility-tv), the Connection Manager interface is available in every TV webOS version LG put out. And, the upstream OSS documentation says that the downstream-undocumented `getinfo` was added in the same API level as the downstream-_documented_ `getStatus`. So assuming that LG didn't do something absurd like remove this function, then re-add it but keep it undocumented, it seems _likely_ that this is available everywhere? And we don't have to handle this erroring?

(Side note, use case for this is getting the wake-on-LAN MAC.)