### PR TITLE
Expose TV network connection information

### DIFF
--- a/aiowebostv/endpoints.py
+++ b/aiowebostv/endpoints.py
@@ -55,6 +55,7 @@ TURN_OFF_SCREEN = "com.webos.service.tvpower/power/turnOffScreen"
 TURN_ON_SCREEN = "com.webos.service.tvpower/power/turnOnScreen"
 GET_CONFIGS = "config/getConfigs"
 GET_MEDIA_FOREGROUND_APP_INFO = "com.webos.media/getForegroundAppInfo"
+GET_CONNECTION_INFO = "com.webos.service.connectionmanager/getinfo"
 
 # webOS TV internal Luna API endpoints
 LUNA_SET_CONFIGS = "com.webos.service.config/setConfigs"

--- a/aiowebostv/models.py
+++ b/aiowebostv/models.py
@@ -11,6 +11,7 @@ class WebOsTvInfo:
     hello: dict[str, Any] = field(default_factory=dict)
     system: dict[str, Any] = field(default_factory=dict)
     software: dict[str, Any] = field(default_factory=dict)
+    connection: dict[str, Any] = field(default_factory=dict)
 
     def clear(self) -> None:
         """Reset all fields to their default values."""

--- a/aiowebostv/webos_client.py
+++ b/aiowebostv/webos_client.py
@@ -269,6 +269,7 @@ class WebOsClient:
                 self.tv_info.system = await self.get_system_info()
 
         self.tv_info.software = await self.get_software_info()
+        self.tv_info.connection = await self.get_connection_info()
 
         subscribe_state_updates = {
             self.subscribe_power_state(self.set_power_state),
@@ -863,6 +864,10 @@ class WebOsClient:
     ) -> dict[str, Any]:
         """Return the system information."""
         return await self.request(ep.GET_SYSTEM_INFO)
+
+    async def get_connection_info(self) -> dict[str, Any]:
+        """Return the network connection information."""
+        return await self.request(ep.GET_CONNECTION_INFO)
 
     async def power_off(self) -> None:
         """Power off TV.


### PR DESCRIPTION
Continues #599 (thanks @strugee) and applies @thecode's review.

Adds `get_connection_info()` and populates a new `WebOsTvInfo.connection` field from `com.webos.service.connectionmanager/getinfo`, exposing the TV's network details — including wired/Wi-Fi/p2p MAC addresses — so consumers (e.g. the Home Assistant `webostv` integration) can discover the MAC for Wake-on-LAN without a manual lookup.

Changes vs #599, per review:
- Broadened naming: `GET_CONNECTION_INFO` / `get_connection_info()` / `tv_info.connection` (was `*_macs`), matching the connection-manager API.
- Added the `connection` field to `WebOsTvInfo` in `models.py` (the piece that was missing / failing CI).

`ruff format`, `ruff check`, and `mypy` all pass locally. (No test suite in the repo.)
