### PR TITLE
Subscribe to current channel only if channel map exists

### DIFF
--- a/aiowebostv/webos_client.py
+++ b/aiowebostv/webos_client.py
@@ -504,7 +504,11 @@ class WebOsClient:
             with suppress(WebOsTvCommandError):
                 await self.subscribe_channels(self.set_channels_state)
 
-        if app_id == "com.webos.app.livetv" and self.tv_state.current_channel is None:
+        if (
+            self.tv_state.channels
+            and app_id == "com.webos.app.livetv"
+            and self.tv_state.current_channel is None
+        ):
             await asyncio.sleep(2)
             with suppress(WebOsTvCommandError):
                 await self.subscribe_current_channel(self.set_current_channel_state)


### PR DESCRIPTION
Fixes #707

I have successfully reproduce the error described at #707, although my TV does not timeout, it does reply with "tuner channel map does not exist" and it make sense not to try to subscribe to the current channel if there are no channels.