### PR TITLE
Suppress WebOsTvServiceNotFoundError when retrieving connection info

### DIFF
--- a/aiowebostv/webos_client.py
+++ b/aiowebostv/webos_client.py
@@ -269,7 +269,8 @@ class WebOsClient:
                 self.tv_info.system = await self.get_system_info()
 
         self.tv_info.software = await self.get_software_info()
-        self.tv_info.connection = await self.get_connection_info()
+        with suppress(WebOsTvServiceNotFoundError):
+            self.tv_info.connection = await self.get_connection_info()
 
         subscribe_state_updates = {
             self.subscribe_power_state(self.set_power_state),


### PR DESCRIPTION
Fix for https://github.com/home-assistant/core/issues/178294
Older TVs does not support this service, as it is only informational data error can be suppressed, `self.tv_info.connection` is already initialized to empty dict and will not break anything.
