### PR TITLE
Fix webOS 26 pairing handshake

### DIFF
--- a/aiowebostv/handshake.py
+++ b/aiowebostv/handshake.py
@@ -1,81 +1,49 @@
 """webOS registration payload."""
 
-SIGNATURE = (
-    "eyJhbGdvcml0aG0iOiJSU0EtU0hBMjU2Iiwia2V5SWQiOiJ0ZXN0LXNpZ25pbm"
-    "ctY2VydCIsInNpZ25hdHVyZVZlcnNpb24iOjF9.hrVRgjCwXVvE2OOSpDZ58hR"
-    "+59aFNwYDyjQgKk3auukd7pcegmE2CzPCa0bJ0ZsRAcKkCTJrWo5iDzNhMBWRy"
-    "aMOv5zWSrthlf7G128qvIlpMT0YNY+n/FaOHE73uLrS/g7swl3/qH/BGFG2Hu4"
-    "RlL48eb3lLKqTt2xKHdCs6Cd4RMfJPYnzgvI4BNrFUKsjkcu+WD4OO2A27Pq1n"
-    "50cMchmcaXadJhGrOqH5YmHdOCj5NSHzJYrsW0HPlpuAx/ECMeIZYDh6RMqaFM"
-    "2DXzdKX9NmmyqzJ3o/0lkk/N97gfVRLW5hA29yeAwaCViZNCP8iC9aO0q9fQoj"
-    "oa7NQnAtw=="
-)
-
 REGISTRATION_PAYLOAD = {
     "forcePairing": False,
     "manifest": {
         "appVersion": "1.1",
         "manifestVersion": 1,
         "permissions": [
-            "LAUNCH",
-            "LAUNCH_WEBAPP",
             "APP_TO_APP",
             "CLOSE",
-            "TEST_OPEN",
-            "TEST_PROTECTED",
             "CONTROL_AUDIO",
             "CONTROL_DISPLAY",
             "CONTROL_INPUT_JOYSTICK",
-            "CONTROL_INPUT_MEDIA_RECORDING",
             "CONTROL_INPUT_MEDIA_PLAYBACK",
+            "CONTROL_INPUT_MEDIA_RECORDING",
+            "CONTROL_INPUT_TEXT",
             "CONTROL_INPUT_TV",
+            "CONTROL_MOUSE_AND_KEYBOARD",
             "CONTROL_POWER",
             "CONTROL_TV_SCREEN",
+            "LAUNCH",
+            "LAUNCH_WEBAPP",
             "READ_APP_STATUS",
+            "READ_COUNTRY_INFO",
             "READ_CURRENT_CHANNEL",
             "READ_INPUT_DEVICE_LIST",
-            "READ_NETWORK_STATE",
-            "READ_RUNNING_APPS",
-            "READ_TV_CHANNEL_LIST",
-            "WRITE_NOTIFICATION_TOAST",
-            "READ_POWER_STATE",
-            "READ_COUNTRY_INFO",
-            "CONTROL_INPUT_TEXT",
-            "CONTROL_MOUSE_AND_KEYBOARD",
             "READ_INSTALLED_APPS",
+            "READ_LGE_SDX",
+            "READ_LGE_TV_INPUT_EVENTS",
+            "READ_NETWORK_STATE",
+            "READ_NOTIFICATIONS",
+            "READ_POWER_STATE",
+            "READ_RUNNING_APPS",
             "READ_SETTINGS",
+            "READ_TV_CHANNEL_LIST",
+            "READ_TV_CURRENT_TIME",
+            "READ_UPDATE_INFO",
+            "SEARCH",
+            "TEST_OPEN",
+            "TEST_PROTECTED",
+            "TEST_SECURE",
+            "UPDATE_FROM_REMOTE_APP",
+            "WRITE_NOTIFICATION_ALERT",
+            "WRITE_NOTIFICATION_TOAST",
+            "WRITE_SETTINGS",
         ],
-        "signatures": [{"signature": SIGNATURE, "signatureVersion": 1}],
-        "signed": {
-            "appId": "com.lge.test",
-            "created": "20140509",
-            "localizedAppNames": {
-                "": "LG Remote App",
-                "ko-KR": "리모컨 앱",
-                "zxx-XX": "ЛГ Rэмotэ AПП",
-            },
-            "localizedVendorNames": {"": "LG Electronics"},
-            "permissions": [
-                "TEST_SECURE",
-                "CONTROL_INPUT_TEXT",
-                "CONTROL_MOUSE_AND_KEYBOARD",
-                "READ_INSTALLED_APPS",
-                "READ_LGE_SDX",
-                "READ_NOTIFICATIONS",
-                "SEARCH",
-                "WRITE_SETTINGS",
-                "WRITE_NOTIFICATION_ALERT",
-                "CONTROL_POWER",
-                "READ_CURRENT_CHANNEL",
-                "READ_RUNNING_APPS",
-                "READ_UPDATE_INFO",
-                "UPDATE_FROM_REMOTE_APP",
-                "READ_LGE_TV_INPUT_EVENTS",
-                "READ_TV_CURRENT_TIME",
-            ],
-            "serial": "2f930e2d2cfe083771f68e4fe7bb07",
-            "vendorId": "com.lge",
-        },
     },
     "pairingType": "PROMPT",
 }

--- a/aiowebostv/webos_client.py
+++ b/aiowebostv/webos_client.py
@@ -268,7 +268,10 @@ class WebOsClient:
             with suppress(WebOsTvResponseTypeError):
                 self.tv_info.system = await self.get_system_info()
 
-        self.tv_info.software = await self.get_software_info()
+        # Try to get software info; will fail if TV was paired with legacy handshake
+        with suppress(WebOsTvResponseTypeError):
+            self.tv_info.software = await self.get_software_info()
+
         with suppress(WebOsTvServiceNotFoundError):
             self.tv_info.connection = await self.get_connection_info()
 

--- a/aiowebostv/webos_client.py
+++ b/aiowebostv/webos_client.py
@@ -268,7 +268,7 @@ class WebOsClient:
             with suppress(WebOsTvResponseTypeError):
                 self.tv_info.system = await self.get_system_info()
 
-        # Try to get software info; will fail if TV was paired with legacy handshake
+        # Try to get software info, most likely to fail with new handshake
         with suppress(WebOsTvResponseTypeError):
             self.tv_info.software = await self.get_software_info()
 


### PR DESCRIPTION
**Based on information collected at: https://github.com/JPersson77/LGTVCompanion/issues/351#issue-4436212594 :**

"UPDATE Aug 16 2026

Removing the signed section from the manifest and including the required permissions in the generic (outer) permissions block seems to restore all necessary access. The design intent of the original manifest seems to be to allow LG first-party remote apps and certified partners to present a signed manifest and get the elevated permission set granted by signature verification with no prompt needed. The outer permissions is what the user accept with the on-screen prompt. Thanks @till69 for sending me on the right path."

---

This PR merge the permissions from the `signed` block with the `non-signed` block so the blacklisted signature is no longer needed, however the TV will not grant the permissions from the `signed` block without new pairing.

The following permissions existed only in the `signed` section:
- READ_LGE_SDX
- READ_LGE_TV_INPUT_EVENTS
- READ_NOTIFICATIONS
- READ_TV_CURRENT_TIME
- READ_UPDATE_INFO
- SEARCH
- TEST_SECURE
- UPDATE_FROM_REMOTE_APP
- WRITE_NOTIFICATION_ALERT
- WRITE_SETTINGS

For `aiowebostv` existing methods the only permission that is missing is 

`READ_UPDATE_INFO`: Permits the client to check the TV's firmware status, including its current software version and whether a new OTA (over-the-air) update is available.

I have tested all existing method that are in use by Home Assistant and they all work without the need to re-pair the TV.
To prevent every existing installation to need to perform new pairing with the TV I think the best option is to silently ignore the "insufficient permissions" error.

```
DEBUG:aiowebostv:send: {'id': 1, 'type': 'request', 'uri': 'ssap://com.webos.service.update/getCurrentSWInformation', 'payload': {}}
DEBUG:aiowebostv:recv: WSMessage(type=<WSMsgType.TEXT: 1>, data='{"type":"error","id":1,"error":"401 insufficient permissions","payload":{}}', extra='')
```

This effectively means that Home Assistant will not update the software version of the TV, however considering the alternative of breaking 65K+ reported installations (with real number probably at least 3 times higher) I think this is a better mitigation.

EDIT: Currently there is no solution for fetching the TV software version, since this is only used to show the current TV firmware it is a minor regression considering the exiting pairing does not break.
