### PR TITLE
Export WebOsTvServiceNotFoundError

### DIFF
--- a/aiowebostv/__init__.py
+++ b/aiowebostv/__init__.py
@@ -1,6 +1,10 @@
 """Provide a package for controlling LG webOS based TVs."""
 
-from .exceptions import WebOsTvCommandError, WebOsTvPairError
+from .exceptions import (
+    WebOsTvCommandError,
+    WebOsTvPairError,
+    WebOsTvServiceNotFoundError,
+)
 from .models import WebOsTvInfo, WebOsTvState
 from .webos_client import WebOsClient
 
@@ -9,5 +13,6 @@ __all__ = [
     "WebOsTvCommandError",
     "WebOsTvInfo",
     "WebOsTvPairError",
+    "WebOsTvServiceNotFoundError",
     "WebOsTvState",
 ]


### PR DESCRIPTION
WebOsTvServiceNotFoundError already exists internally for the "404 no such service or method" case, but wasn't part of the public API. Exporting it so consumers (e.g. Home Assistant core) can distinguish a TV that lacks a given SSAP service from other command failures, instead of catching everything as a generic WebOsTvCommandError.