### PR TITLE
Restore signed manifest registration with an unsigned fallback

### DIFF
--- a/aiowebostv/handshake.py
+++ b/aiowebostv/handshake.py
@@ -1,6 +1,89 @@
-"""webOS registration payload."""
+"""webOS registration payloads."""
 
-REGISTRATION_PAYLOAD = {
+# Newer firmware rejects this signature as blacklisted
+SIGNATURE = (
+    "eyJhbGdvcml0aG0iOiJSU0EtU0hBMjU2Iiwia2V5SWQiOiJ0ZXN0LXNpZ25pbm"
+    "ctY2VydCIsInNpZ25hdHVyZVZlcnNpb24iOjF9.hrVRgjCwXVvE2OOSpDZ58hR"
+    "+59aFNwYDyjQgKk3auukd7pcegmE2CzPCa0bJ0ZsRAcKkCTJrWo5iDzNhMBWRy"
+    "aMOv5zWSrthlf7G128qvIlpMT0YNY+n/FaOHE73uLrS/g7swl3/qH/BGFG2Hu4"
+    "RlL48eb3lLKqTt2xKHdCs6Cd4RMfJPYnzgvI4BNrFUKsjkcu+WD4OO2A27Pq1n"
+    "50cMchmcaXadJhGrOqH5YmHdOCj5NSHzJYrsW0HPlpuAx/ECMeIZYDh6RMqaFM"
+    "2DXzdKX9NmmyqzJ3o/0lkk/N97gfVRLW5hA29yeAwaCViZNCP8iC9aO0q9fQoj"
+    "oa7NQnAtw=="
+)
+
+# Only a signed manifest is granted the elevated permissions
+SIGNED_REGISTRATION_PAYLOAD = {
+    "forcePairing": False,
+    "manifest": {
+        "appVersion": "1.1",
+        "manifestVersion": 1,
+        "permissions": [
+            "LAUNCH",
+            "LAUNCH_WEBAPP",
+            "APP_TO_APP",
+            "CLOSE",
+            "TEST_OPEN",
+            "TEST_PROTECTED",
+            "CONTROL_AUDIO",
+            "CONTROL_DISPLAY",
+            "CONTROL_INPUT_JOYSTICK",
+            "CONTROL_INPUT_MEDIA_RECORDING",
+            "CONTROL_INPUT_MEDIA_PLAYBACK",
+            "CONTROL_INPUT_TV",
+            "CONTROL_POWER",
+            "CONTROL_TV_SCREEN",
+            "READ_APP_STATUS",
+            "READ_CURRENT_CHANNEL",
+            "READ_INPUT_DEVICE_LIST",
+            "READ_NETWORK_STATE",
+            "READ_RUNNING_APPS",
+            "READ_TV_CHANNEL_LIST",
+            "WRITE_NOTIFICATION_TOAST",
+            "READ_POWER_STATE",
+            "READ_COUNTRY_INFO",
+            "CONTROL_INPUT_TEXT",
+            "CONTROL_MOUSE_AND_KEYBOARD",
+            "READ_INSTALLED_APPS",
+            "READ_SETTINGS",
+        ],
+        "signatures": [{"signature": SIGNATURE, "signatureVersion": 1}],
+        "signed": {
+            "appId": "com.lge.test",
+            "created": "20140509",
+            "localizedAppNames": {
+                "": "LG Remote App",
+                "ko-KR": "리모컨 앱",
+                "zxx-XX": "ЛГ Rэмotэ AПП",
+            },
+            "localizedVendorNames": {"": "LG Electronics"},
+            "permissions": [
+                "TEST_SECURE",
+                "CONTROL_INPUT_TEXT",
+                "CONTROL_MOUSE_AND_KEYBOARD",
+                "READ_INSTALLED_APPS",
+                "READ_LGE_SDX",
+                "READ_NOTIFICATIONS",
+                "SEARCH",
+                "WRITE_SETTINGS",
+                "WRITE_NOTIFICATION_ALERT",
+                "CONTROL_POWER",
+                "READ_CURRENT_CHANNEL",
+                "READ_RUNNING_APPS",
+                "READ_UPDATE_INFO",
+                "UPDATE_FROM_REMOTE_APP",
+                "READ_LGE_TV_INPUT_EVENTS",
+                "READ_TV_CURRENT_TIME",
+            ],
+            "serial": "2f930e2d2cfe083771f68e4fe7bb07",
+            "vendorId": "com.lge",
+        },
+    },
+    "pairingType": "PROMPT",
+}
+
+# Fallback limited to the permissions the pairing prompt grants
+UNSIGNED_REGISTRATION_PAYLOAD = {
     "forcePairing": False,
     "manifest": {
         "appVersion": "1.1",
@@ -48,9 +131,14 @@ REGISTRATION_PAYLOAD = {
     "pairingType": "PROMPT",
 }
 
-
-REGISTRATION_MESSAGE = {
+SIGNED_REGISTRATION_MESSAGE = {
     "type": "register",
     "id": "register_0",
-    "payload": REGISTRATION_PAYLOAD,
+    "payload": SIGNED_REGISTRATION_PAYLOAD,
+}
+
+UNSIGNED_REGISTRATION_MESSAGE = {
+    "type": "register",
+    "id": "register_0",
+    "payload": UNSIGNED_REGISTRATION_PAYLOAD,
 }

--- a/aiowebostv/webos_client.py
+++ b/aiowebostv/webos_client.py
@@ -24,7 +24,7 @@ from .exceptions import (
     WebOsTvResponseTypeError,
     WebOsTvServiceNotFoundError,
 )
-from .handshake import REGISTRATION_MESSAGE
+from .handshake import SIGNED_REGISTRATION_MESSAGE, UNSIGNED_REGISTRATION_MESSAGE
 from .models import WebOsTvInfo, WebOsTvState
 
 CONNECT_TIMEOUT = 2  # Timeout for connecting to the TV
@@ -44,6 +44,10 @@ WSS_PORT = 3001
 _LOGGER = logging.getLogger(__package__)
 
 
+class _ManifestRejectedError(WebOsTvPairError):
+    """Tv rejected the manifest without prompting the user."""
+
+
 class WebOsClient:
     """webOS TV client class."""
 
@@ -58,6 +62,7 @@ class WebOsClient:
         """Initialize the client."""
         self.host = host
         self.client_key = client_key
+        self.signed_manifest = True
         self.command_count: int = 0
         self.timeout_connect = connect_timeout
         self.heartbeat = heartbeat
@@ -130,7 +135,10 @@ class WebOsClient:
 
     def registration_msg(self) -> dict[str, Any]:
         """Create registration message."""
-        handshake = copy.deepcopy(REGISTRATION_MESSAGE)
+        if self.signed_manifest:
+            handshake = copy.deepcopy(SIGNED_REGISTRATION_MESSAGE)
+        else:
+            handshake = copy.deepcopy(UNSIGNED_REGISTRATION_MESSAGE)
         handshake["payload"]["client-key"] = self.client_key  # type: ignore[index]
         return handshake
 
@@ -223,6 +231,9 @@ class WebOsClient:
             response = await ws.receive_json()
         _LOGGER.debug("recv(%s): registration", self.host)
 
+        if response["type"] == "error":
+            raise _ManifestRejectedError(response["error"])
+
         if (
             response["type"] == "response"
             and response["payload"]["pairingType"] == "PROMPT"
@@ -237,12 +248,31 @@ class WebOsClient:
             )
             if response["type"] == "error":
                 raise WebOsTvPairError(response["error"])
-            if response["type"] == "registered":
-                self.client_key = response["payload"]["client-key"]
+
+        if response["type"] == "registered":
+            self.client_key = response["payload"]["client-key"]
 
         if not self.client_key:
             error = "Client key not set, pairing failed."
             raise WebOsTvPairError(error)
+
+    async def _create_registered_main_ws(self) -> ClientWebSocketResponse:
+        """Create main websocket connection and register with the tv."""
+        ws = await self._create_main_ws()
+        try:
+            await self._get_hello_info(ws)
+            await self._get_pre_reg_system_info(ws)
+            await self._check_registration(ws)
+        except BaseException as ex:
+            await ws.close()
+            if not isinstance(ex, _ManifestRejectedError) or not self.signed_manifest:
+                raise
+            # Retry unsigned, this tv rejects the signed manifest outright
+            _LOGGER.debug("register(%s): %s", self.host, ex)
+            self.signed_manifest = False
+            return await self._create_registered_main_ws()
+
+        return ws
 
     async def _create_input_ws(self) -> ClientWebSocketResponse:
         """Create input websocket connection.
@@ -268,7 +298,7 @@ class WebOsClient:
             with suppress(WebOsTvResponseTypeError):
                 self.tv_info.system = await self.get_system_info()
 
-        # Try to get software info, most likely to fail with new handshake
+        # Software info is unavailable with the unsigned manifest
         with suppress(WebOsTvResponseTypeError):
             self.tv_info.software = await self.get_software_info()
 
@@ -359,10 +389,7 @@ class WebOsClient:
         input_ws: ClientWebSocketResponse | None = None
         self._ensure_client_session()
         try:
-            main_ws = await self._create_main_ws()
-            await self._get_hello_info(main_ws)
-            await self._get_pre_reg_system_info(main_ws)
-            await self._check_registration(main_ws)
+            main_ws = await self._create_registered_main_ws()
             self._rx_tasks.add(asyncio.create_task(self._rx_msgs_main_ws(main_ws)))
             self.connection = main_ws
             input_ws = await self._create_input_ws()


### PR DESCRIPTION
## Summary

#719 switched registration to an unsigned manifest to fix webOS 26 pairing.
That also drops the signed-only permissions on firmware which still accepts the
signed manifest. This registers signed first and retries unsigned if the TV
rejects it.

Lost today: `READ_UPDATE_INFO` (so `tv_info.software` is empty) and some others.

This fixes #728

## Changes

- Split `handshake.py` into signed and unsigned payloads.
- `_check_registration()` raises on an `error`-type register response, and
  honors a `registered` reply with no preceding `PROMPT` response.
- `_create_registered_main_ws()` retries once with the unsigned manifest.

## Testing

LG OLED48C25LB, webOS 7.0, firmware 33.31.68. Probe of 17 read-only endpoints,
freshly paired per run.

| Endpoint | Permission | 0.10.0 | This PR |
| --- | --- | --- | --- |
| `getCurrentSWInformation` | `READ_UPDATE_INFO` | 401 | OK |

Other 15 identical. No re-pair needed: connecting with a key issued by an
unsigned 0.10.0 pairing kept the key, showed no prompt, and gained
`READ_UPDATE_INFO`.

## Known limitation

Untested against hardware that rejects the signed manifest. Forcing it with a
corrupted signature showed this firmware sends no register-time error, it
registers and silently drops the permissions. The retry assumes webOS 26
responds with an `error` frame. Confirmation from a webOS 26 user welcome.